### PR TITLE
Fixed memory leaks in SocketClient and All Facades

### DIFF
--- a/src/IQFeed.CSharpApiClient/Common/RawMessageHandler.cs
+++ b/src/IQFeed.CSharpApiClient/Common/RawMessageHandler.cs
@@ -60,6 +60,7 @@ namespace IQFeed.CSharpApiClient.Common
                 binaryWriter.Close();
                 client.MessageReceived -= SocketClientOnMessageReceived;
                 _lookupDispatcher.Add(client);
+                ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
 
             return await res.Task.ConfigureAwait(false);

--- a/src/IQFeed.CSharpApiClient/Lookup/Chains/ChainsFacade.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Chains/ChainsFacade.cs
@@ -82,6 +82,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Chains
             {
                 client.MessageReceived -= SocketClientOnMessageReceived;
                 _lookupDispatcher.Add(client);
+                ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
 
             return await res.Task.ConfigureAwait(false);

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/HistoricalFacade.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/HistoricalFacade.cs
@@ -236,6 +236,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical
             {
                 client.MessageReceived -= SocketClientOnMessageReceived;
                 _lookupDispatcher.Add(client);
+                ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
 
             return await res.Task.ConfigureAwait(false);

--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -43,6 +43,7 @@ namespace IQFeed.CSharpApiClient.Socket
         {
             if (_disposed)
                 throw new ObjectDisposedException($"Can't connect because SocketClient is disposed.");
+
             _clientSocket.Connect(_hostEndPoint);
             Connected.RaiseEvent(this, EventArgs.Empty);
 
@@ -63,12 +64,14 @@ namespace IQFeed.CSharpApiClient.Socket
         {
             if (_disposed)
                 throw new ObjectDisposedException($"Can't send because SocketClient is disposed.");
+
             if (_clientSocket.Connected)
             {
                 _clientSocket.Send(Encoding.ASCII.GetBytes(message));
-            } else
+            }
+            else
             {
-                throw new SocketException((int) SocketError.NotConnected);
+                throw new SocketException((int)SocketError.NotConnected);
             }
         }
 
@@ -129,8 +132,8 @@ namespace IQFeed.CSharpApiClient.Socket
         {
             if (_disposed)
                 return;
-            _disposed = true;
 
+            _disposed = true;
             _clientSocket?.Dispose();
             _socketMessageHandler.Dispose();
             _readEventArgs?.Dispose();

--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -6,7 +6,7 @@ using IQFeed.CSharpApiClient.Extensions;
 
 namespace IQFeed.CSharpApiClient.Socket
 {
-    public class SocketClient
+    public class SocketClient : IDisposable
     {
         public event EventHandler<SocketMessageEventArgs> MessageReceived;
         public event EventHandler Connected;
@@ -17,6 +17,7 @@ namespace IQFeed.CSharpApiClient.Socket
         private readonly int _bufferSize;
         private readonly SocketMessageHandler _socketMessageHandler;
         private readonly SocketMessageEventArgs _socketMessageEventArgs;
+        private readonly SocketAsyncEventArgs _readEventArgs;
 
         public SocketClient(string hostname, int port, int bufferSize = 8192)
         {
@@ -32,42 +33,42 @@ namespace IQFeed.CSharpApiClient.Socket
             _hostEndPoint = new IPEndPoint(addressList[addressList.Length - 1], port);
             _clientSocket = new System.Net.Sockets.Socket(_hostEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            _socketMessageHandler = new SocketMessageHandler(_bufferSize, '\n');    // TODO: could be injected in the constructor
+            _socketMessageHandler = new SocketMessageHandler(_bufferSize, '\n'); // TODO: could be injected in the constructor
             _socketMessageEventArgs = new SocketMessageEventArgs();
+            _readEventArgs = new SocketAsyncEventArgs();
         }
+
 
         public void Connect()
         {
+            if (_disposed)
+                throw new ObjectDisposedException($"Can't connect because SocketClient is disposed.");
             _clientSocket.Connect(_hostEndPoint);
             Connected.RaiseEvent(this, EventArgs.Empty);
 
-            SocketAsyncEventArgs readEventArgs = new SocketAsyncEventArgs();
-            readEventArgs.Completed += new EventHandler<SocketAsyncEventArgs>(IO_Completed);
-            readEventArgs.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
+            _readEventArgs.Completed += new EventHandler<SocketAsyncEventArgs>(IO_Completed);
+            _readEventArgs.SetBuffer(new byte[_bufferSize], 0, _bufferSize);
 
             // As soon as the client is connected, post a receive to the connection 
-            bool willRaiseEvent = _clientSocket.ReceiveAsync(readEventArgs);
+            bool willRaiseEvent = _clientSocket.ReceiveAsync(_readEventArgs);
             if (!willRaiseEvent)
             {
-                ProcessReceive(readEventArgs);
+                ProcessReceive(_readEventArgs);
             }
         }
 
-        public void Disconnect()
-        {
-            _disposed = true;
-            _clientSocket.Dispose();
-        }
+        public void Disconnect() { Dispose(); }
 
         public void Send(string message)
         {
+            if (_disposed)
+                throw new ObjectDisposedException($"Can't connect because SocketClient is disposed.");
             if (_clientSocket.Connected)
             {
                 _clientSocket.Send(Encoding.ASCII.GetBytes(message));
-            }
-            else
+            } else
             {
-                throw new SocketException((int)SocketError.NotConnected);
+                throw new SocketException((int) SocketError.NotConnected);
             }
         }
 
@@ -108,7 +109,8 @@ namespace IQFeed.CSharpApiClient.Socket
                 }
 
                 // don't attempt another receive if socket is already disposed
-                if (_disposed) return;
+                if (_disposed)
+                    return;
 
                 var willRaiseEvent = _clientSocket.ReceiveAsync(e);
                 if (!willRaiseEvent)
@@ -118,9 +120,24 @@ namespace IQFeed.CSharpApiClient.Socket
             }
         }
 
-        protected virtual void ProcessSend(SocketAsyncEventArgs e)
+        protected virtual void ProcessSend(SocketAsyncEventArgs e) { throw new NotImplementedException(); }
+
+        #region IDisposable
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        public void Dispose()
         {
-            throw new NotImplementedException();
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            _clientSocket?.Dispose();
+            _socketMessageHandler.Dispose();
+            _readEventArgs?.Dispose();
+            MessageReceived = null;
+            Connected = null;
         }
+
+        #endregion
     }
 }

--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -62,7 +62,7 @@ namespace IQFeed.CSharpApiClient.Socket
         public void Send(string message)
         {
             if (_disposed)
-                throw new ObjectDisposedException($"Can't connect because SocketClient is disposed.");
+                throw new ObjectDisposedException($"Can't send because SocketClient is disposed.");
             if (_clientSocket.Connected)
             {
                 _clientSocket.Send(Encoding.ASCII.GetBytes(message));

--- a/src/IQFeed.CSharpApiClient/Socket/SocketMessageHandler.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketMessageHandler.cs
@@ -1,9 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using IQFeed.CSharpApiClient.Extensions;
 
 namespace IQFeed.CSharpApiClient.Socket
 {
-    public class SocketMessageHandler
+    public class SocketMessageHandler : IDisposable
     {
         private readonly char _delimeter;
 
@@ -59,12 +60,23 @@ namespace IQFeed.CSharpApiClient.Socket
             if (_completeStream.Position == 0)
                 return 0;
 
-            var length = (int)_completeStream.Length;
+            var length = (int) _completeStream.Length;
             _completeStream.Position = 0;
             _completeStream.Read(_readBytes, 0, length);
             _completeStream.SetLength(0);
             output = _readBytes;
             return length;
         }
+
+        #region IDisposable
+
+        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        public void Dispose()
+        {
+            _completeStream?.Dispose();
+            _remainderStream?.Dispose();
+        }
+
+        #endregion
     }
 }

--- a/src/IQFeed.CSharpApiClient/Socket/SocketMessageHandler.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketMessageHandler.cs
@@ -60,7 +60,7 @@ namespace IQFeed.CSharpApiClient.Socket
             if (_completeStream.Position == 0)
                 return 0;
 
-            var length = (int) _completeStream.Length;
+            var length = (int)_completeStream.Length;
             _completeStream.Position = 0;
             _completeStream.Read(_readBytes, 0, length);
             _completeStream.SetLength(0);

--- a/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1Snapshot.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1Snapshot.cs
@@ -49,6 +49,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
             {
                 _level1MessageHandler.Fundamental -= Level1ClientOnFundamental;
                 ReqUnwatch(symbol);
+                ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
 
             return await res.Task.ConfigureAwait(false);
@@ -75,6 +76,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
                 _level1MessageHandler.Summary -= Level1ClientOnUpdate;
                 _level1MessageHandler.Update -= Level1ClientOnUpdate;
                 ReqUnwatch(symbol);
+                ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
 
             return await res.Task.ConfigureAwait(false);


### PR DESCRIPTION
Fixed memory leaks in:
-SocketClient, Disposage
-All Facades, Caused by not disposing CancellationTokenSource.

The leaks resulted in build-up of TickMessage/IntervalMessage after every request.
Which ended up causing the program to crash in few minutes.
Signed-off-by: Eli <elibelash@gmail.com>