### PR TITLE
Fix for .NET Core startup hang - IsPortOpen never succeeded

### DIFF
--- a/src/IQFeed.CSharpApiClient/Socket/SocketDiagnostic.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketDiagnostic.cs
@@ -15,7 +15,7 @@ namespace IQFeed.CSharpApiClient.Socket
 
                 try
                 {
-                    using (var client = new TcpClient())
+                    using (var client = new TcpClient(AddressFamily.InterNetwork))
                     {
                         var result = client.BeginConnect(host, port, null, null);
                         var success = result.AsyncWaitHandle.WaitOne(timeout);


### PR DESCRIPTION
Fix for #58 

Allows IsPortOpen to succeed and return in .NET Core.