### PR TITLE
Adjusted regex so last comma is optional for interval bar messages

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Derivative/Messages/IntervalBarMessageTest.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Derivative/Messages/IntervalBarMessageTest.cs
@@ -1,0 +1,41 @@
+﻿using IQFeed.CSharpApiClient.Streaming.Derivative.Messages;
+using NUnit.Framework;
+using System;
+
+namespace IQFeed.CSharpApiClient.Tests.Streaming.Derivative
+{
+    public class IntervalBarMessageTest
+    {
+        [TestCase(
+            ",BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0",
+            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
+            101.23, 99.98, 100.93, 143562, 745, 0, null)]
+        [TestCase(
+            ",BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0,",
+            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
+            101.23, 99.98, 100.93, 143562, 745, 0, null)]
+        [TestCase(
+            "test-request,BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0,",
+            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
+            101.23, 99.98, 100.93, 143562, 745, 0, "test-request")]
+        [TestCase(
+            "test-request,BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0",
+            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
+            101.23, 99.98, 100.93, 143562, 745, 0, "test-request")]
+        public void Should_Parse(
+            string bar, IntervalBarType type, string symbol, int year, int month, int day,
+            int hour, int minute, int seconds, decimal open, decimal high, decimal low,
+            decimal last, int cumulativeVolume, int intervalVolume, int numberOfTrades,
+            string requestId)
+        {
+            Assert.IsTrue(IntervalBarMessage.TryParse(
+                bar, out IntervalBarMessage<decimal> msg));
+            Assert.AreEqual(
+                new IntervalBarMessage<decimal>(
+                    type, symbol, new DateTime(year, month, day, hour, minute, seconds),
+                    open, high, low, last, cumulativeVolume, intervalVolume,
+                    numberOfTrades, requestId).ToString(),
+                msg.ToString());
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Derivative/Messages/IntervalBarMessageTest.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Derivative/Messages/IntervalBarMessageTest.cs
@@ -1,41 +1,41 @@
-﻿using IQFeed.CSharpApiClient.Streaming.Derivative.Messages;
+﻿using System;
+using IQFeed.CSharpApiClient.Streaming.Derivative.Messages;
+using IQFeed.CSharpApiClient.Tests.Common;
+using IQFeed.CSharpApiClient.Tests.Common.TestCases;
 using NUnit.Framework;
-using System;
 
-namespace IQFeed.CSharpApiClient.Tests.Streaming.Derivative
+namespace IQFeed.CSharpApiClient.Tests.Streaming.Derivative.Messages
 {
     public class IntervalBarMessageTest
     {
-        [TestCase(
-            ",BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0",
-            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
-            101.23, 99.98, 100.93, 143562, 745, 0, null)]
-        [TestCase(
-            ",BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0,",
-            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
-            101.23, 99.98, 100.93, 143562, 745, 0, null)]
-        [TestCase(
-            "test-request,BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0,",
-            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
-            101.23, 99.98, 100.93, 143562, 745, 0, "test-request")]
-        [TestCase(
-            "test-request,BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0",
-            IntervalBarType.C, "AAPL", 2018, 1, 1, 9, 30, 0, 100.01,
-            101.23, 99.98, 100.93, 143562, 745, 0, "test-request")]
-        public void Should_Parse(
-            string bar, IntervalBarType type, string symbol, int year, int month, int day,
-            int hour, int minute, int seconds, decimal open, decimal high, decimal low,
-            decimal last, int cumulativeVolume, int intervalVolume, int numberOfTrades,
-            string requestId)
+        [Test, TestCaseSource(typeof(CultureNameTestCase), nameof(CultureNameTestCase.CultureNames))]
+        public void Should_Parse(string cultureName)
         {
-            Assert.IsTrue(IntervalBarMessage.TryParse(
-                bar, out IntervalBarMessage<decimal> msg));
-            Assert.AreEqual(
-                new IntervalBarMessage<decimal>(
-                    type, symbol, new DateTime(year, month, day, hour, minute, seconds),
-                    open, high, low, last, cumulativeVolume, intervalVolume,
-                    numberOfTrades, requestId).ToString(),
-                msg.ToString());
+            // Arrange
+            TestHelper.SetThreadCulture(cultureName);
+            var message = "BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0";
+            
+            // Act
+            var intervalBarMessage = new IntervalBarMessage<double>(IntervalBarType.C, "AAPL", new DateTime(2018, 1, 1, 9, 30, 0), 100.01, 101.23, 99.98, 100.93, 143562, 745, 0);
+            var intervalBarMessageParsed = IntervalBarMessage.Parse(message);
+
+            // Assert
+            Assert.AreEqual(intervalBarMessage, intervalBarMessageParsed);
+        }
+
+        [Test, TestCaseSource(typeof(CultureNameTestCase), nameof(CultureNameTestCase.CultureNames))]
+        public void Should_Parse_Without_RequestId(string cultureName)
+        {
+            // Arrange
+            TestHelper.SetThreadCulture(cultureName);
+            var message = "TESTREQUEST,BC,AAPL,2018-01-01 09:30:00,100.01,101.23,99.98,100.93,143562,745,0";
+
+            // Act
+            var intervalBarMessage = new IntervalBarMessage<double>(IntervalBarType.C, "AAPL", new DateTime(2018, 1, 1, 9, 30, 0), 100.01, 101.23, 99.98, 100.93, 143562, 745, 0, "TESTREQUEST");
+            var intervalBarMessageParsed = IntervalBarMessage.ParseWithRequestId(message);
+
+            // Assert
+            Assert.AreEqual(intervalBarMessage, intervalBarMessageParsed);
         }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
@@ -9,8 +9,8 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
     {
         public const string IntervalBarMessageDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
-        public const string IntervalBarMessageWithRequestIdPattern = @"^.*,B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?$";
-        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?$";
+        public const string IntervalBarMessageWithRequestIdPattern = @"^.*,B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*$";
+        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*$";
 
         public static readonly Regex IntervalBarMessageWithRequestIdRegex = new Regex(IntervalBarMessageWithRequestIdPattern);
         public static readonly Regex IntervalBarMessageWithoutRequestIdRegex = new Regex(IntervalBarMessageWithoutRequestIdPattern);

--- a/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
@@ -9,8 +9,8 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
     {
         public const string IntervalBarMessageDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
-        public const string IntervalBarMessageWithRequestIdPattern = @"^.*,B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,$";
-        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,$";
+        public const string IntervalBarMessageWithRequestIdPattern = @"^.*,B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?$";
+        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?s$";
 
         public static readonly Regex IntervalBarMessageWithRequestIdRegex = new Regex(IntervalBarMessageWithRequestIdPattern);
         public static readonly Regex IntervalBarMessageWithoutRequestIdRegex = new Regex(IntervalBarMessageWithoutRequestIdPattern);

--- a/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
@@ -10,7 +10,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
         public const string IntervalBarMessageDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
         public const string IntervalBarMessageWithRequestIdPattern = @"^.*,B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?$";
-        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?s$";
+        public const string IntervalBarMessageWithoutRequestIdPattern = @"^B[U|H|C],.*,.*,.*,.*,.*,.*,.*,.*,.*,?$";
 
         public static readonly Regex IntervalBarMessageWithRequestIdRegex = new Regex(IntervalBarMessageWithRequestIdPattern);
         public static readonly Regex IntervalBarMessageWithoutRequestIdRegex = new Regex(IntervalBarMessageWithoutRequestIdPattern);


### PR DESCRIPTION
According to IQFeed documentation there is no comma at the end of an interval bar message. I've experienced this myself running IQFeed and had issues with this library before making this change.