### PR TITLE
Changed LastSize & TotalVolume from int to long

### DIFF
--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/HistoricalBar.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/HistoricalBar.cs
@@ -18,7 +18,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
             double open,
             double close,
             long totalVolume,
-            int periodVolume,
+            long periodVolume,
             int totalTrade,
             int periodTrade,
             double vwap)
@@ -41,7 +41,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
         public double Open { get; set; }
         public double Close { get; set; }
         public long TotalVolume { get; set; }
-        public int PeriodVolume { get; set; }
+        public long PeriodVolume { get; set; }
         public int TotalTrade { get; set; }
         public int PeriodTrade { get; set; }
         public double VWAP { get; set; }
@@ -51,16 +51,16 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
             var values = csv.SplitFeedMessage();
 
             return new HistoricalBar(
-                DateTime.ParseExact(values[0], HistoricalBarDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[1], CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                double.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                long.Parse(values[5], CultureInfo.InvariantCulture),
-                int.Parse(values[6], CultureInfo.InvariantCulture),
-                int.Parse(values[7], CultureInfo.InvariantCulture),
-                int.Parse(values[8], CultureInfo.InvariantCulture),
-            double.Parse(values[9], CultureInfo.InvariantCulture));
+                timestamp: DateTime.ParseExact(values[0], HistoricalBarDateTimeFormat, CultureInfo.InvariantCulture),
+                high: double.Parse(values[1], CultureInfo.InvariantCulture),
+                low: double.Parse(values[2], CultureInfo.InvariantCulture),
+                open: double.Parse(values[3], CultureInfo.InvariantCulture),
+                close: double.Parse(values[4], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[5], CultureInfo.InvariantCulture),
+                periodVolume: long.Parse(values[6], CultureInfo.InvariantCulture),
+                totalTrade: int.Parse(values[7], CultureInfo.InvariantCulture),
+                periodTrade: int.Parse(values[8], CultureInfo.InvariantCulture),
+                vwap: double.Parse(values[9], CultureInfo.InvariantCulture));
         }
 
         public static IEnumerable<HistoricalBar> ParseFromFile(string path)
@@ -110,7 +110,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
                 hashCode = (hashCode * 397) ^ Open.GetHashCode();
                 hashCode = (hashCode * 397) ^ Close.GetHashCode();
                 hashCode = (hashCode * 397) ^ TotalVolume.GetHashCode();
-                hashCode = (hashCode * 397) ^ PeriodVolume;
+                hashCode = (hashCode * 397) ^ PeriodVolume.GetHashCode();
                 hashCode = (hashCode * 397) ^ TotalTrade;
                 hashCode = (hashCode * 397) ^ PeriodTrade;
                 hashCode = (hashCode * 397) ^ VWAP.GetHashCode();

--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
@@ -45,7 +45,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
             DateTime? nextTimestamp = null;
             HistoricalBar currentBar = null;
 
-            var totalVolume = 0;
+            var totalVolume = 0L;
             var totalTrade = 0;
 
             foreach (var tick in tickMessages)
@@ -127,7 +127,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
         {
             HistoricalBar currentBar = null;
 
-            var totalVolume = 0;
+            var totalVolume = 0L;
             var totalTrade = 0;
 
             foreach (var tick in tickMessages)

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/DailyWeeklyMonthlyMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/DailyWeeklyMonthlyMessage.cs
@@ -36,13 +36,13 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var values = message.SplitFeedMessage();
 
             return new DailyWeeklyMonthlyMessage(
-                DateTime.ParseExact(values[0], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[1], CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                double.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                long.Parse(values[5], CultureInfo.InvariantCulture),
-                int.Parse(values[6], CultureInfo.InvariantCulture));
+                timestamp: DateTime.ParseExact(values[0], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture),
+                high: double.Parse(values[1], CultureInfo.InvariantCulture),
+                low: double.Parse(values[2], CultureInfo.InvariantCulture),
+                open: double.Parse(values[3], CultureInfo.InvariantCulture),
+                close: double.Parse(values[4], CultureInfo.InvariantCulture),
+                periodVolume: long.Parse(values[5], CultureInfo.InvariantCulture),
+                openInterest: int.Parse(values[6], CultureInfo.InvariantCulture));
         }
 
         public static DailyWeeklyMonthlyMessage ParseWithRequestId(string message)
@@ -51,14 +51,14 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var requestId = values[0];
 
             return new DailyWeeklyMonthlyMessage(
-                DateTime.ParseExact(values[1], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                double.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                double.Parse(values[5], CultureInfo.InvariantCulture),
-                long.Parse(values[6], CultureInfo.InvariantCulture),
-                int.Parse(values[7], CultureInfo.InvariantCulture),
-                requestId);
+                timestamp: DateTime.ParseExact(values[1], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture),
+                high: double.Parse(values[2], CultureInfo.InvariantCulture),
+                low: double.Parse(values[3], CultureInfo.InvariantCulture),
+                open: double.Parse(values[4], CultureInfo.InvariantCulture),
+                close: double.Parse(values[5], CultureInfo.InvariantCulture),
+                periodVolume: long.Parse(values[6], CultureInfo.InvariantCulture),
+                openInterest: int.Parse(values[7], CultureInfo.InvariantCulture),
+                requestId: requestId);
         }
 
         public static IEnumerable<DailyWeeklyMonthlyMessage> ParseFromFile(string path, bool hasRequestId = false)

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IIntervalMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IIntervalMessage.cs
@@ -9,7 +9,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         double Low { get; }
         int NumberOfTrades { get; }
         double Open { get; }
-        int PeriodVolume { get; }
+        long PeriodVolume { get; }
         long TotalVolume { get; }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/ITickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/ITickMessage.cs
@@ -6,9 +6,9 @@
         char BasisForLast { get; }
         double Bid { get; }
         double Last { get; }
-        int LastSize { get; }
+        long LastSize { get; }
+        long TotalVolume { get; }
         long TickId { get; }
-        int TotalVolume { get; }
         string TradeConditions { get; }
         int TradeMarketCenter { get; }
     }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/ITickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/ITickMessage.cs
@@ -6,7 +6,7 @@
         char BasisForLast { get; }
         double Bid { get; }
         double Last { get; }
-        long LastSize { get; }
+        int LastSize { get; }
         long TotalVolume { get; }
         long TickId { get; }
         string TradeConditions { get; }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IntervalMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IntervalMessage.cs
@@ -10,7 +10,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
     {
         public const string IntervalDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
-        public IntervalMessage(DateTime timestamp, double high, double low, double open, double close, long totalVolume, int periodVolume, int numberOfTrades, string requestId = null)
+        public IntervalMessage(DateTime timestamp, double high, double low, double open, double close, long totalVolume, long periodVolume, int numberOfTrades, string requestId = null)
         {
             Timestamp = timestamp;
             High = high;
@@ -29,7 +29,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         public double Open { get; private set; }
         public double Close { get; private set; }
         public long TotalVolume { get; private set; }
-        public int PeriodVolume { get; private set; }
+        public long PeriodVolume { get; private set; }
         public int NumberOfTrades { get; private set; }
         public string RequestId { get; private set; }
 
@@ -38,31 +38,30 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var values = message.SplitFeedMessage();
 
             return new IntervalMessage(
-                DateTime.ParseExact(values[0], IntervalDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[1], CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                double.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                long.Parse(values[5], CultureInfo.InvariantCulture),
-                int.Parse(values[6], CultureInfo.InvariantCulture),
-                int.Parse(values[7], CultureInfo.InvariantCulture));
+                timestamp: DateTime.ParseExact(values[0], IntervalDateTimeFormat, CultureInfo.InvariantCulture),
+                high: double.Parse(values[1], CultureInfo.InvariantCulture),
+                low: double.Parse(values[2], CultureInfo.InvariantCulture),
+                open: double.Parse(values[3], CultureInfo.InvariantCulture),
+                close: double.Parse(values[4], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[5], CultureInfo.InvariantCulture),
+                periodVolume: long.Parse(values[6], CultureInfo.InvariantCulture),
+                numberOfTrades: int.Parse(values[7], CultureInfo.InvariantCulture));
         }
 
         public static IntervalMessage ParseWithRequestId(string message)
         {
             var values = message.SplitFeedMessage();
-            var requestId = values[0];
 
             return new IntervalMessage(
-                DateTime.ParseExact(values[1], IntervalDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                double.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                double.Parse(values[5], CultureInfo.InvariantCulture),
-                long.Parse(values[6], CultureInfo.InvariantCulture),
-                int.Parse(values[7], CultureInfo.InvariantCulture),
-                int.Parse(values[8], CultureInfo.InvariantCulture),
-                requestId);
+                timestamp: DateTime.ParseExact(values[1], IntervalDateTimeFormat, CultureInfo.InvariantCulture),
+                high: double.Parse(values[2], CultureInfo.InvariantCulture),
+                low: double.Parse(values[3], CultureInfo.InvariantCulture),
+                open: double.Parse(values[4], CultureInfo.InvariantCulture),
+                close: double.Parse(values[5], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[6], CultureInfo.InvariantCulture),
+                periodVolume: long.Parse(values[7], CultureInfo.InvariantCulture),
+                numberOfTrades: int.Parse(values[8], CultureInfo.InvariantCulture),
+                requestId: values[0]);
         }
 
         public static IEnumerable<IntervalMessage> ParseFromFile(string path, bool hasRequestId = false)

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -10,7 +10,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
     {
         public const string TickDateTimeFormat = "yyyy-MM-dd HH:mm:ss.ffffff";
 
-        public TickMessage(DateTime timestamp, double last, int lastSize, int totalVolume, double bid, double ask,
+        public TickMessage(DateTime timestamp, double last, long lastSize, long totalVolume, double bid, double ask,
             long tickId, char basisForLast, int tradeMarketCenter, string tradeConditions, string requestId = null)
         {
             Timestamp = timestamp;
@@ -28,8 +28,8 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
 
         public DateTime Timestamp { get; private set; }
         public double Last { get; private set; }
-        public int LastSize { get; private set; }
-        public int TotalVolume { get; private set; }
+        public long LastSize { get; private set; }
+        public long TotalVolume { get; private set; }
         public double Bid { get; private set; }
         public double Ask { get; private set; }
         public long TickId { get; private set; }
@@ -43,16 +43,16 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var values = message.SplitFeedMessage();
 
             return new TickMessage(
-                DateTime.ParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[1], CultureInfo.InvariantCulture),
-                int.Parse(values[2], CultureInfo.InvariantCulture),
-                int.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                double.Parse(values[5], CultureInfo.InvariantCulture),
-                long.Parse(values[6], CultureInfo.InvariantCulture),
-                char.Parse(values[7]),
-                int.Parse(values[8], CultureInfo.InvariantCulture),
-                values[9]);
+                timestamp: DateTime.ParseExact(s: values[index0: 0], format: TickDateTimeFormat, CultureInfo.InvariantCulture),
+                last: double.Parse(values[index0: 1], CultureInfo.InvariantCulture),
+                lastSize: long.Parse(values[index0: 2], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[index0: 3], CultureInfo.InvariantCulture),
+                bid: double.Parse(values[index0: 4], CultureInfo.InvariantCulture),
+                ask: double.Parse(values[index0: 5], CultureInfo.InvariantCulture),
+                tickId: long.Parse(values[index0: 6], CultureInfo.InvariantCulture),
+                basisForLast: char.Parse(values[index0: 7]),
+                tradeMarketCenter: int.Parse(s: values[index0: 8], CultureInfo.InvariantCulture),
+                tradeConditions: values[index0: 9]);
         }
 
         public static TickMessage ParseWithRequestId(string message)
@@ -63,8 +63,8 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             return new TickMessage(
                 DateTime.ParseExact(values[1], TickDateTimeFormat, CultureInfo.InvariantCulture),
                 double.Parse(values[2], CultureInfo.InvariantCulture),
-                int.Parse(values[3], CultureInfo.InvariantCulture),
-                int.Parse(values[4], CultureInfo.InvariantCulture),
+                long.Parse(values[3], CultureInfo.InvariantCulture),
+                long.Parse(values[4], CultureInfo.InvariantCulture),
                 double.Parse(values[5], CultureInfo.InvariantCulture),
                 double.Parse(values[6], CultureInfo.InvariantCulture),
                 long.Parse(values[7], CultureInfo.InvariantCulture),

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -43,16 +43,16 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var values = message.SplitFeedMessage();
 
             return new TickMessage(
-                timestamp: DateTime.ParseExact(s: values[index0: 0], format: TickDateTimeFormat, CultureInfo.InvariantCulture),
-                last: double.Parse(values[index0: 1], CultureInfo.InvariantCulture),
-                lastSize: long.Parse(values[index0: 2], CultureInfo.InvariantCulture),
-                totalVolume: long.Parse(values[index0: 3], CultureInfo.InvariantCulture),
-                bid: double.Parse(values[index0: 4], CultureInfo.InvariantCulture),
-                ask: double.Parse(values[index0: 5], CultureInfo.InvariantCulture),
-                tickId: long.Parse(values[index0: 6], CultureInfo.InvariantCulture),
-                basisForLast: char.Parse(values[index0: 7]),
-                tradeMarketCenter: int.Parse(s: values[index0: 8], CultureInfo.InvariantCulture),
-                tradeConditions: values[index0: 9]);
+                timestamp: DateTime.ParseExact(s: values[0], format: TickDateTimeFormat, CultureInfo.InvariantCulture),
+                last: double.Parse(values[1], CultureInfo.InvariantCulture),
+                lastSize: long.Parse(values[2], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[3], CultureInfo.InvariantCulture),
+                bid: double.Parse(values[4], CultureInfo.InvariantCulture),
+                ask: double.Parse(values[5], CultureInfo.InvariantCulture),
+                tickId: long.Parse(values[6], CultureInfo.InvariantCulture),
+                basisForLast: char.Parse(values[7]),
+                tradeMarketCenter: int.Parse(s: values[8], CultureInfo.InvariantCulture),
+                tradeConditions: values[9]);
         }
 
         public static TickMessage ParseWithRequestId(string message)

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -10,7 +10,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
     {
         public const string TickDateTimeFormat = "yyyy-MM-dd HH:mm:ss.ffffff";
 
-        public TickMessage(DateTime timestamp, double last, long lastSize, long totalVolume, double bid, double ask,
+        public TickMessage(DateTime timestamp, double last, int lastSize, long totalVolume, double bid, double ask,
             long tickId, char basisForLast, int tradeMarketCenter, string tradeConditions, string requestId = null)
         {
             Timestamp = timestamp;
@@ -28,7 +28,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
 
         public DateTime Timestamp { get; private set; }
         public double Last { get; private set; }
-        public long LastSize { get; private set; }
+        public int LastSize { get; private set; }
         public long TotalVolume { get; private set; }
         public double Bid { get; private set; }
         public double Ask { get; private set; }
@@ -45,7 +45,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             return new TickMessage(
                 timestamp: DateTime.ParseExact(s: values[0], format: TickDateTimeFormat, CultureInfo.InvariantCulture),
                 last: double.Parse(values[1], CultureInfo.InvariantCulture),
-                lastSize: long.Parse(values[2], CultureInfo.InvariantCulture),
+                lastSize: int.Parse(values[2], CultureInfo.InvariantCulture),
                 totalVolume: long.Parse(values[3], CultureInfo.InvariantCulture),
                 bid: double.Parse(values[4], CultureInfo.InvariantCulture),
                 ask: double.Parse(values[5], CultureInfo.InvariantCulture),
@@ -63,7 +63,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             return new TickMessage(
                 timestamp: DateTime.ParseExact(values[1], TickDateTimeFormat, CultureInfo.InvariantCulture),
                 last: double.Parse(values[2], CultureInfo.InvariantCulture),
-                lastSize: long.Parse(values[3], CultureInfo.InvariantCulture),
+                lastSize: int.Parse(values[3], CultureInfo.InvariantCulture),
                 totalVolume: long.Parse(values[4], CultureInfo.InvariantCulture),
                 bid: double.Parse(values[5], CultureInfo.InvariantCulture),
                 ask: double.Parse(values[6], CultureInfo.InvariantCulture),

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -61,17 +61,17 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             var requestId = values[0];
 
             return new TickMessage(
-                DateTime.ParseExact(values[1], TickDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[2], CultureInfo.InvariantCulture),
-                long.Parse(values[3], CultureInfo.InvariantCulture),
-                long.Parse(values[4], CultureInfo.InvariantCulture),
-                double.Parse(values[5], CultureInfo.InvariantCulture),
-                double.Parse(values[6], CultureInfo.InvariantCulture),
-                long.Parse(values[7], CultureInfo.InvariantCulture),
-                char.Parse(values[8]),
-                int.Parse(values[9], CultureInfo.InvariantCulture),
-                values[10],
-                requestId);
+                timestamp: DateTime.ParseExact(values[1], TickDateTimeFormat, CultureInfo.InvariantCulture),
+                last: double.Parse(values[2], CultureInfo.InvariantCulture),
+                lastSize: long.Parse(values[3], CultureInfo.InvariantCulture),
+                totalVolume: long.Parse(values[4], CultureInfo.InvariantCulture),
+                bid: double.Parse(values[5], CultureInfo.InvariantCulture),
+                ask: double.Parse(values[6], CultureInfo.InvariantCulture),
+                tickId: long.Parse(values[7], CultureInfo.InvariantCulture),
+                basisForLast: char.Parse(values[8]),
+                tradeMarketCenter: int.Parse(values[9], CultureInfo.InvariantCulture),
+                tradeConditions: values[10],
+                requestId: requestId);
         }
 
         public static IEnumerable<TickMessage> ParseFromFile(string path, bool hasRequestId = false)

--- a/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IIntervalBarMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IIntervalBarMessage.cs
@@ -15,12 +15,12 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
         /// <summary>
         /// Last cummulative volume in the interval
         /// </summary>
-        int CummulativeVolume { get; }
+        long CummulativeVolume { get; }
 
         /// <summary>
         /// Interval volume for the interval
         /// </summary>
-        int IntervalVolume { get; }
+        long IntervalVolume { get; }
 
         /// <summary>
         /// Number of trades in the interval (only valid for tick interval)

--- a/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Derivative/Messages/IntervalBarMessage.cs
@@ -23,8 +23,8 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
             double high,
             double low,
             double last,
-            int cummulativeVolume,
-            int intervalVolume,
+            long cummulativeVolume,
+            long intervalVolume,
             int numberOfTrades,
             string requestId = null)
         {
@@ -52,12 +52,12 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
         /// <summary>
         /// Last cummulative volume in the interval
         /// </summary>
-        public int CummulativeVolume { get; private set; }
+        public long CummulativeVolume { get; private set; }
 
         /// <summary>
         /// Interval volume for the interval
         /// </summary>
-        public int IntervalVolume { get; private set; }
+        public long IntervalVolume { get; private set; }
 
         /// <summary>
         /// Number of trades in the interval (only valid for tick interval)
@@ -77,8 +77,8 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
             double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out var high);
             double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out var low);
             double.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out var last);
-            int.TryParse(values[7], NumberStyles.Any, CultureInfo.InvariantCulture, out var cummulativeVolume);
-            int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out var intervalVolume);
+            long.TryParse(values[7], NumberStyles.Any, CultureInfo.InvariantCulture, out var cummulativeVolume);
+            long.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out var intervalVolume);
             int.TryParse(values[9], NumberStyles.Any, CultureInfo.InvariantCulture, out var numberOfTrades);
 
             return new IntervalBarMessage(type, symbol, timestamp, open, high, low, last, cummulativeVolume, intervalVolume, numberOfTrades);
@@ -96,8 +96,8 @@ namespace IQFeed.CSharpApiClient.Streaming.Derivative.Messages
             double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out var high);
             double.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out var low);
             double.TryParse(values[7], NumberStyles.Any, CultureInfo.InvariantCulture, out var last);
-            int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out var cummulativeVolume);
-            int.TryParse(values[9], NumberStyles.Any, CultureInfo.InvariantCulture, out var intervalVolume);
+            long.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out var cummulativeVolume);
+            long.TryParse(values[9], NumberStyles.Any, CultureInfo.InvariantCulture, out var intervalVolume);
             int.TryParse(values[10], NumberStyles.Any, CultureInfo.InvariantCulture, out var numberOfTrades);
 
             return new IntervalBarMessage(type, symbol, timestamp, open, high, low, last, cummulativeVolume, intervalVolume, numberOfTrades, requestId);

--- a/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1DynamicFields.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1DynamicFields.cs
@@ -76,7 +76,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
         public string Symbol { get; private set; }
         public int Tick { get; private set; }
         public int TickID { get; private set; }
-        public int TotalVolume { get; private set; }
+        public long TotalVolume { get; private set; }
         public string Type { get; private set; }
         public double Volatility { get; private set; }
         public double VWAP { get; private set; }
@@ -147,7 +147,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
             string symbol,
             int tick,
             int tickID,
-            int totalVolume,
+            long totalVolume,
             string type,
             double volatility,
             double vwap)
@@ -294,7 +294,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
             string symbol = default;
             int tick = default;
             int tickID = default;
-            int totalVolume = default;
+            long totalVolume = default;
             string type = default;
             double volatility = default;
             double vwap = default;
@@ -509,7 +509,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
                         int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out tickID);
                         break;
                     case DynamicFieldset.TotalVolume:
-                        int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume);
+                        long.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume);
                         break;
                     case DynamicFieldset.Type:
                         type = value;


### PR DESCRIPTION
Related to issue #93 
Because it is `TotalVolume`, there is no other way but to change it to `long`. All the ticks for that symbol after the mentioned error, are supposed to come in with an even larger `TotalVolume`.
About `LastSize`, It is argueable if it should be still `int` or `long`. I believe Its a question of time until this will also be erroneous.
If `LastSize` will remain `int` then at-least we have to `try-catch` overflow-exception and properly print a detailed error because it was a mess to detect the cause.