### PR TITLE
Added IqFeed data parse exceptions handling

### DIFF
--- a/src/IQFeed.CSharpApiClient/Common/Exceptions/BadDataIQFeedException.cs
+++ b/src/IQFeed.CSharpApiClient/Common/Exceptions/BadDataIQFeedException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IQFeed.CSharpApiClient.Common.Exceptions
+{
+    public class BadDataIQFeedException : IQFeedException
+    {
+        public BadDataIQFeedException(string message, string badFieldName) : this("", message, badFieldName)
+        {
+
+        }
+
+        public BadDataIQFeedException(string request, string message, string badFieldName) : base(request, message, String.Format("Cannot parse field \"{0}\" from IqFeed", badFieldName), "")
+        {
+            BadFieldName = badFieldName;
+        }
+
+        public string BadFieldName { get; }
+    }
+}

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using IQFeed.CSharpApiClient.Common.Exceptions;
 using IQFeed.CSharpApiClient.Extensions;
 using IQFeed.CSharpApiClient.Lookup.Common;
 
@@ -42,16 +43,61 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         {
             var values = message.SplitFeedMessage();
 
+            if (!DateTime.TryParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime timestamp))
+            {
+                throw new BadDataIQFeedException(message, nameof(timestamp));
+            }
+
+            if (!double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out double last))
+            {
+                throw new BadDataIQFeedException(message, nameof(last));
+            }
+
+            if (!int.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out int lastSize))
+            {
+                throw new BadDataIQFeedException(message, nameof(lastSize));
+            }
+
+            if (!int.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out int totalVolume))
+            {
+                throw new BadDataIQFeedException(message, nameof(totalVolume));
+            }
+
+            if (!double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out double bid))
+            {
+                throw new BadDataIQFeedException(message, nameof(bid));
+            }
+
+            if (!double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out double ask))
+            {
+                throw new BadDataIQFeedException(message, nameof(ask));
+            }
+
+            if (!long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out long tickId))
+            {
+                throw new BadDataIQFeedException(message, nameof(tickId));
+            }
+
+            if (!char.TryParse(values[7], out char basisForLast))
+            {
+                throw new BadDataIQFeedException(message, nameof(basisForLast));
+            }
+
+            if (!int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out int tradeMarketCenter))
+            {
+                throw new BadDataIQFeedException(message, nameof(tradeMarketCenter));
+            }
+
             return new TickMessage(
-                DateTime.ParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture),
-                double.Parse(values[1], CultureInfo.InvariantCulture),
-                int.Parse(values[2], CultureInfo.InvariantCulture),
-                int.Parse(values[3], CultureInfo.InvariantCulture),
-                double.Parse(values[4], CultureInfo.InvariantCulture),
-                double.Parse(values[5], CultureInfo.InvariantCulture),
-                long.Parse(values[6], CultureInfo.InvariantCulture),
-                char.Parse(values[7]),
-                int.Parse(values[8], CultureInfo.InvariantCulture),
+                timestamp,
+                last,
+                lastSize,
+                totalVolume,
+                bid,
+                ask,
+                tickId,
+                basisForLast,
+                tradeMarketCenter,
                 values[9]);
         }
 

--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -11,6 +11,7 @@ namespace IQFeed.CSharpApiClient.Socket
     {
         public event EventHandler<SocketMessageEventArgs> MessageReceived;
         public event EventHandler Connected;
+        public event EventHandler<Exception> ExceptionRaised;
 
         public static bool ForceIPv4 { get; set; } = true;
 
@@ -113,7 +114,14 @@ namespace IQFeed.CSharpApiClient.Socket
                     _socketMessageEventArgs.Count = count;
 
                     // inform that the socket just received complete message
-                    MessageReceived.RaiseEvent(this, _socketMessageEventArgs);
+                    try
+                    {
+                        MessageReceived.RaiseEvent(this, _socketMessageEventArgs);
+                    }
+                    catch (Exception ex)
+                    {
+                        ExceptionRaised?.Invoke(this, ex);
+                    }
                 }
 
                 // don't attempt another receive if socket is already disposed


### PR DESCRIPTION
Added marshalling of parse exceptions to the client calling context, so that the client code can now catch these exceptions and make it's own processing, for example:

```
try {
   var intraDayTicks = (await lookupClient.Historical.GetHistoryTickDatapointsAsync(ticker, 1, 
          IQFeed.CSharpApiClient.Lookup.Historical.Enums.DataDirection.Newest)).ToArray();
} catch (IQFeed.CSharpApiClient.Common.Exceptions.NoDataIQFeedException) {
}
catch (IQFeed.CSharpApiClient.Common.Exceptions.BadDataIQFeedException) {
   // catching parse exceptions here
}
```