### PR TITLE
Reimplemented LookupRateLimiter

### DIFF
--- a/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
+++ b/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IQFeed.CSharpApiClient.Common.Exceptions;
+using IQFeed.CSharpApiClient.Examples.Common;
+using IQFeed.CSharpApiClient.Lookup;
+using IQFeed.CSharpApiClient.Lookup.Historical.Messages;
+
+namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
+{
+    public class ConcurrencyBenchmarkHistoricalExample : ConcurrentHistoricalBase, IExample
+    {
+        public bool Enable => true; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
+        public string Name => nameof(ConcurrencyBenchmarkHistoricalExample);
+        private const int NumberOfConcurrentClients = 8;
+
+        public ConcurrencyBenchmarkHistoricalExample() : base(LookupClientFactory.CreateNew(NumberOfConcurrentClients), NumberOfConcurrentClients) { }
+
+        private class Ref<T>
+        {
+            public T Value;
+        }
+
+        public void Run()
+        {
+            // Configure your credentials for IQConnect in user environment variable or app.config !!!
+            // Check the documentation for more information.               
+
+            // Run IQConnect launcher
+            IQFeedLauncher.Start();
+
+            // Connect the LookupClient created from the constructor
+            LookupClient.Connect();
+
+
+            const int numberOfSymbols = 50;
+            const int iterations = NumberOfConcurrentClients * numberOfSymbols; //symbols
+            var rand = new Random(1);
+            var symbols = Repeat(MarketData.GetSymbols().OrderBy(_ => rand.Next()).ToArray()).Take(iterations).ToArray();
+            var tasks = new Task[iterations];
+
+            Console.WriteLine($"Number of Concurrent Tasks: {iterations}");
+            Console.WriteLine($"Number of Symbols: {numberOfSymbols}");
+            Console.WriteLine("Benchmark starting 0ms");
+            var sw = Stopwatch.StartNew();
+            Ref<int> messagesFetched = new Ref<int>() { Value = 0 };
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var fetched = messagesFetched;
+                tasks[i] = LookupClient.Historical.GetHistoryDailyDatapointsAsync(symbols[i], 100).ContinueWith(t =>
+                {
+                    try
+                    {
+                        //accumulate th
+                        fetched.Value += t.GetAwaiter().GetResult().Count();
+                    }
+                    catch (NoDataIQFeedException) { }
+                    catch (System.AggregateException e)
+                    {
+                        //handle aggregated exception due to unwrapped exceptions from Task<T>
+                        AggregateException agg = e;
+                        while (e.InnerExceptions.Count == 1 && e.InnerExceptions[0] is AggregateException)
+                            agg = (AggregateException)e.InnerExceptions[0];
+
+                        if (!(e.InnerExceptions[0] is NoDataIQFeedException))
+                            throw;
+                    }
+                });
+            }
+
+            Console.WriteLine("All tasks allocated " + sw.ElapsedMilliseconds + "ms");
+            sw.Restart();
+            Task.WaitAll(tasks);
+            sw.Stop();
+            Console.WriteLine("All tasks completed " + sw.ElapsedMilliseconds);
+            Console.WriteLine("Requests per second :" + (sw.ElapsedMilliseconds) / (double)iterations);
+
+            Console.WriteLine($"\nFetched {messagesFetched.Value} Daily messages for {iterations} requests in {sw.Elapsed.TotalMilliseconds} ms.");
+        }
+
+        private IEnumerable<T> Repeat<T>(IEnumerable<T> collection)
+        {
+            while (true)
+                foreach (var item in collection)
+                {
+                    yield return item;
+                }
+        }
+
+        protected override Task ProcessSymbols()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
+++ b/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
@@ -14,10 +14,10 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
 {
     public class ConcurrencyBenchmarkHistoricalExample : ConcurrentHistoricalBase, IExample
     {
-        public bool Enable => false; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
+        public bool Enable => true; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
         public string Name => nameof(ConcurrencyBenchmarkHistoricalExample);
-        private const int NumberOfConcurrentClients = 16;
-        private const int Requests = 500;
+        private const int NumberOfConcurrentClients = 16; //best use Environment.ProcessorCount
+        private const int Requests = 100;
 
         public ConcurrencyBenchmarkHistoricalExample() : base(LookupClientFactory.CreateNew(NumberOfConcurrentClients), NumberOfConcurrentClients) { }
 
@@ -26,14 +26,14 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
             public T Value;
         }
 
-        public void Run()
-        {
+        public void Run() {
+            
             // Configure your credentials for IQConnect in user environment variable or app.config !!!
             // Check the documentation for more information.               
 
             // Run IQConnect launcher
             IQFeedLauncher.Start();
-
+            
             // Connect the LookupClient created from the constructor
             LookupClient.Connect();
 
@@ -70,13 +70,14 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
                     }
                 });
             }
-
+            
+            Console.WriteLine("Number of Clients: " + NumberOfConcurrentClients);
             Console.WriteLine("All tasks allocated " + sw.ElapsedMilliseconds + "ms");
             sw.Restart();
             Task.WaitAll(tasks);
             sw.Stop();
             Console.WriteLine("All tasks completed " + sw.ElapsedMilliseconds);
-            Console.WriteLine("Requests per second :" + (sw.ElapsedMilliseconds) / (double)Requests);
+            Console.WriteLine($"average call request time: {sw.Elapsed.TotalMilliseconds / (double)Requests}ms");
 
             Console.WriteLine($"\nFetched {messagesFetched.Value} Daily messages for {Requests} requests in {sw.Elapsed.TotalMilliseconds} ms.");
         }

--- a/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
+++ b/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
@@ -16,8 +16,8 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
     {
         public bool Enable => true; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
         public string Name => nameof(ConcurrencyBenchmarkHistoricalExample);
-        private const int NumberOfConcurrentClients = 50; //best use Environment.ProcessorCount
-        private const int Requests = 500;
+        private const int NumberOfConcurrentClients = 200; //best use Environment.ProcessorCount
+        private const int Requests = 1000;
 
         public ConcurrencyBenchmarkHistoricalExample() : base(LookupClientFactory.CreateNew(NumberOfConcurrentClients), NumberOfConcurrentClients) { }
 

--- a/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
+++ b/src/IQFeed.CSharpApiClient.Examples/Examples/ConcurrencyBenchmark/ConcurrencyBenchmarkHistoricalExample.cs
@@ -16,8 +16,8 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
     {
         public bool Enable => true; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
         public string Name => nameof(ConcurrencyBenchmarkHistoricalExample);
-        private const int NumberOfConcurrentClients = 16; //best use Environment.ProcessorCount
-        private const int Requests = 100;
+        private const int NumberOfConcurrentClients = 50; //best use Environment.ProcessorCount
+        private const int Requests = 500;
 
         public ConcurrencyBenchmarkHistoricalExample() : base(LookupClientFactory.CreateNew(NumberOfConcurrentClients), NumberOfConcurrentClients) { }
 
@@ -62,11 +62,11 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.ConcurrentHistorical
                     {
                         //handle aggregated exception due to unwrapped exceptions from Task<T>
                         AggregateException agg = e;
-                        while (e.InnerExceptions.Count == 1 && e.InnerExceptions[0] is AggregateException)
+                        while (agg.InnerExceptions.Count == 1 && agg.InnerExceptions[0] is AggregateException)
                             agg = (AggregateException)e.InnerExceptions[0];
 
-                        if (!(e.InnerExceptions[0] is NoDataIQFeedException))
-                            throw;
+                        if (!(agg.InnerExceptions[0] is NoDataIQFeedException))
+                            Console.WriteLine(agg.InnerExceptions[0]);
                     }
                 });
             }

--- a/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
@@ -15,7 +15,146 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup
     public class LookupRateLimiterTests
     {
         [Test]
-        public async Task Should_Rate_Limit_By_Throughput()
+        public async Task Should_Rate_Limit_Measure_By_Iterations()
+        {
+            // Arrange
+            const int requestsPerSecond = 50;
+            const int experimentDurationSeconds = 10;
+            const int iterations = experimentDurationSeconds * requestsPerSecond;
+
+            // Act
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
+            Stopwatch sw = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                await lookupRateLimiter.WaitAsync();
+                lookupRateLimiter.Release();
+            }
+
+            sw.Stop();
+
+            Console.WriteLine($"requests: {iterations}");
+            Console.WriteLine($"elapsed: {sw.Elapsed.TotalMilliseconds}ms");
+            Console.WriteLine($"average call request time: {sw.Elapsed.TotalMilliseconds / iterations}ms, Interval: {lookupRateLimiter.Interval.TotalMilliseconds}ms");
+
+            // Assert
+
+            Assert.That(sw.Elapsed.TotalMilliseconds / iterations,
+                Is.EqualTo(lookupRateLimiter.Interval.TotalMilliseconds).Within(3).Percent
+                    .And.GreaterThanOrEqualTo(lookupRateLimiter.Interval.TotalMilliseconds)); //value has to be higher than 20ms to match serverside.
+        }
+
+        [Test]
+        public async Task Should_Rate_Limit_Measure_By_Time()
+        {
+            // Arrange
+            const int seconds = 15;
+            var totalSecondsTicks = TimeSpan.FromSeconds(seconds);
+
+            const int requestsPerSecond = 50;
+            var requestsCount = 0;
+
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
+
+            // Act
+            var sw = Stopwatch.StartNew();
+
+            while (true)
+            {
+                await lookupRateLimiter.WaitAsync();
+                lookupRateLimiter.Release();
+
+                requestsCount++;
+                if (sw.Elapsed >= totalSecondsTicks)
+                {
+                    sw.Stop();
+                    break;
+                }
+            }
+
+            Console.WriteLine($"requests: {requestsCount}");
+            Console.WriteLine($"elapsed: {sw.Elapsed.TotalMilliseconds}ms");
+            Console.WriteLine($"average call request time: {sw.Elapsed.TotalMilliseconds / requestsCount}ms, Interval: {lookupRateLimiter.Interval.TotalMilliseconds}ms");
+
+
+            // Assert
+            Assert.That(sw.Elapsed.TotalMilliseconds / requestsCount,
+                Is.EqualTo(lookupRateLimiter.Interval.TotalMilliseconds).Within(3).Percent
+                    .And.GreaterThanOrEqualTo(lookupRateLimiter.Interval.TotalMilliseconds)); //value has to be higher than 20ms to match serverside.
+        }
+
+
+        [Test]
+        public async Task Should_Rate_Limit_Measure_By_Iterations_HighPrecision()
+        {
+            // Arrange
+            const int requestsPerSecond = 50;
+            const int experimentDurationSeconds = 10;
+            const int iterations = experimentDurationSeconds * requestsPerSecond;
+
+            // Act
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond, higherPrecision: true);
+            Stopwatch sw = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                await lookupRateLimiter.WaitAsync();
+                lookupRateLimiter.Release();
+            }
+
+            sw.Stop();
+
+            Console.WriteLine($"requests: {iterations}");
+            Console.WriteLine($"elapsed: {sw.Elapsed.TotalMilliseconds}ms");
+            Console.WriteLine($"average call request time: {sw.Elapsed.TotalMilliseconds / iterations}ms, Interval: {lookupRateLimiter.Interval.TotalMilliseconds}ms");
+
+            // Assert
+
+            Assert.That(sw.Elapsed.TotalMilliseconds / iterations,
+                Is.EqualTo(lookupRateLimiter.Interval.TotalMilliseconds).Within(3).Percent
+                    .And.GreaterThanOrEqualTo(lookupRateLimiter.Interval.TotalMilliseconds)); //value has to be higher than 20ms to match serverside.
+        }
+
+        [Test]
+        public async Task Should_Rate_Limit_Measure_By_Time_HighPrecision()
+        {
+            // Arrange
+            const int seconds = 15;
+            var totalSecondsTicks = TimeSpan.FromSeconds(seconds);
+
+            const int requestsPerSecond = 50;
+            var requestsCount = 0;
+
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond, higherPrecision: true);
+
+            // Act
+            var sw = Stopwatch.StartNew();
+
+            while (true)
+            {
+                await lookupRateLimiter.WaitAsync();
+                lookupRateLimiter.Release();
+
+                requestsCount++;
+                if (sw.Elapsed >= totalSecondsTicks)
+                {
+                    sw.Stop();
+                    break;
+                }
+            }
+
+            Console.WriteLine($"requests: {requestsCount}");
+            Console.WriteLine($"elapsed: {sw.Elapsed.TotalMilliseconds}ms");
+            Console.WriteLine($"average call request time: {sw.Elapsed.TotalMilliseconds / requestsCount}ms, Interval: {lookupRateLimiter.Interval.TotalMilliseconds}ms");
+
+            // Assert
+            Assert.That(sw.Elapsed.TotalMilliseconds / requestsCount,
+                Is.EqualTo(lookupRateLimiter.Interval.TotalMilliseconds).Within(3).Percent
+                    .And.GreaterThanOrEqualTo(lookupRateLimiter.Interval.TotalMilliseconds)); //value has to be higher than 20ms to match serverside.
+        }
+
+
+        [Test]
+        public async Task Should_Rate_Limit_By_Throughput_Original()
         {
             // Arrange
             var totalSeconds = TimeSpan.FromSeconds(15).TotalSeconds;
@@ -35,6 +174,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup
                 {
                     await lookupRateLimiter.WaitAsync();
                     Interlocked.Increment(ref requestsCount);
+                    lookupRateLimiter.Release();
                 }
             }, cts.Token);
 

--- a/src/IQFeed.CSharpApiClient/Common/FrequencyStopwatch.cs
+++ b/src/IQFeed.CSharpApiClient/Common/FrequencyStopwatch.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace IQFeed.CSharpApiClient.Common {
+    internal struct FrequencyStopwatch {
+        private readonly long _frequency;
+        private long _elapsed;
+        private long _startTimeStamp;
+        private bool _isRunning;
+
+        public static readonly long Frequency;
+
+        /// <summary>Indicates whether the timer is based on a high-resolution performance counter. This field is read-only.</summary>
+        public static readonly bool IsHighResolution;
+
+        public DateTime StartTime => new DateTime(IsHighResolution ? (long) (_elapsed * TickFrequency) : _elapsed);
+
+        public FrequencyStopwatch(long frequency) {
+            _frequency = frequency;
+            _elapsed = 0;
+            _startTimeStamp = 0;
+            _isRunning = false;
+        }
+
+        public FrequencyStopwatch(long frequency, bool start) {
+            _frequency = frequency;
+            _elapsed = 0;
+            _isRunning = true;
+            _startTimeStamp = start ? GetTimestamp() : 0;
+        }
+
+        public static readonly double TickFrequency;
+
+        static FrequencyStopwatch() {
+            if (!Native.QueryPerformanceFrequency(out Frequency)) {
+                IsHighResolution = false;
+                Frequency = 10000000L;
+                TickFrequency = 1.0;
+            } else {
+                IsHighResolution = true;
+                TickFrequency = 10000000.0;
+                TickFrequency /= Frequency;
+            }
+        }
+
+        /// <summary>Starts, or resumes, measuring elapsed time for an interval.</summary>
+        public void Start() {
+            if (_isRunning)
+                return;
+            _startTimeStamp = GetTimestamp();
+            _isRunning = true;
+        }
+
+        /// <summary>Initializes a new <see cref="T:System.Diagnostics.StopwatchStruct" /> instance, sets the elapsed time property to zero, and starts measuring elapsed time.</summary>
+        /// <returns>A <see cref="T:System.Diagnostics.StopwatchStruct" /> that has just begun measuring elapsed time.</returns>
+        public static FrequencyStopwatch StartNew(long frequency) {
+            return new FrequencyStopwatch(frequency, true);
+        }
+
+        /// <summary>Stops measuring elapsed time for an interval.</summary>
+        public void Stop() {
+            if (!_isRunning)
+                return;
+            _elapsed += GetTimestamp() - _startTimeStamp;
+            _isRunning = false;
+            if (_elapsed >= 0L)
+                return;
+            _elapsed = 0L;
+        }
+
+        /// <summary>Stops time interval measurement and resets the elapsed time to zero.</summary>
+        public void Reset() {
+            _elapsed = 0;
+            _startTimeStamp = 0;
+            _isRunning = false;
+        }
+
+        /// <summary>Stops time interval measurement, resets the elapsed time to zero, and starts measuring elapsed time.</summary>
+        public void Restart() {
+            _elapsed = 0L;
+            _startTimeStamp = GetTimestamp();
+            _isRunning = true;
+        }
+
+        /// <summary>If the time elapsed so far surpassed <paramref name="stepFrequency"/> then it'll return ignore any excess time that do not fit into a step that we'll taken into account on next checkpoint.</summary>
+        /// <remarks>Has no isRunning check</remarks>
+        /// <returns>Ticks</returns>
+        public long Checkpoint() {
+            long elapsedFreq = GetTimestamp() - _startTimeStamp;
+            if (elapsedFreq >= _frequency) {
+                elapsedFreq -= elapsedFreq % _frequency; //trim
+                _startTimeStamp += elapsedFreq;
+                return FromCurrentFrequency(elapsedFreq);
+            } else
+                return 0;
+        }
+
+        /// <summary>If the time elapsed so far surpassed <paramref name="stepFrequency"/> then it'll return ignore any excess time that do not fit into a step that we'll taken into account on next checkpoint.</summary>
+        /// <remarks>Has no isRunning check</remarks>
+        /// <returns>Ticks</returns>
+        public long Excess => FromCurrentFrequency((GetTimestamp() - _startTimeStamp) % _frequency);
+
+        /// <summary>If the time elapsed so far surpassed <paramref name="stepFrequency"/> then it'll return ignore any excess time that do not fit into a step that we'll taken into account on next checkpoint.</summary>
+        /// <remarks>Has no isRunning check</remarks>
+        /// <returns>Milliseconds</returns>
+        public int ExcessMilliseconds => (int) new TimeSpan(FromCurrentFrequency((GetTimestamp() - _startTimeStamp) % _frequency)).TotalMilliseconds;
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ToCurrentFrequency(long milliseconds) {
+            return IsHighResolution ? (long) (milliseconds * TickFrequency) : milliseconds;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long FromCurrentFrequency(long performanceTicks) {
+            return IsHighResolution ? (long) (performanceTicks / TickFrequency) : performanceTicks;
+        }
+
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Diagnostics.StopwatchStruct" /> timer is running.</summary>
+        /// <returns>
+        /// <see langword="true" /> if the <see cref="T:System.Diagnostics.StopwatchStruct" /> instance is currently running and measuring elapsed time for an interval; otherwise, <see langword="false" />.</returns>
+
+        public bool IsRunning => _isRunning;
+
+        /// <summary>Gets the total elapsed time measured by the current instance.</summary>
+        /// <returns>A read-only <see cref="T:System.TimeSpan" /> representing the total elapsed time measured by the current instance.</returns>
+
+        public TimeSpan Elapsed => new TimeSpan(GetElapsedDateTimeTicks());
+
+        /// <summary>Gets the total elapsed time measured by the current instance, in milliseconds.</summary>
+        /// <returns>A read-only long integer representing the total number of milliseconds measured by the current instance.</returns>
+
+        public long ElapsedMilliseconds => GetElapsedDateTimeTicks() / 10000L;
+
+        /// <summary>Gets the total elapsed time measured by the current instance, in timer ticks.</summary>
+        /// <returns>A read-only long integer representing the total number of timer ticks measured by the current instance.</returns>
+
+        public long ElapsedTicks => GetRawElapsedTicks();
+
+
+        /// <summary>Gets the current number of ticks in the timer mechanism.</summary>
+        /// <returns>A long integer representing the tick counter value of the underlying timer mechanism.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long GetTimestamp() {
+            if (!IsHighResolution)
+                return DateTime.UtcNow.Ticks;
+            Native.QueryPerformanceCounter(out var num);
+            return num;
+        }
+
+        private long GetRawElapsedTicks() {
+            long elapsed = this._elapsed;
+            if (!_isRunning)
+                return elapsed;
+            long num = GetTimestamp() - _startTimeStamp;
+            elapsed += num;
+
+            return elapsed;
+        }
+
+        private long GetElapsedDateTimeTicks() {
+            long rawElapsedTicks = GetRawElapsedTicks();
+            return IsHighResolution ? (long) (rawElapsedTicks * TickFrequency) : rawElapsedTicks;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long FromRaw(long rawCounter) {
+            return IsHighResolution ? (long) (rawCounter * TickFrequency) : rawCounter;
+        }
+
+        private static class Native {
+            [DllImport("kernel32.dll")]
+            public static extern bool QueryPerformanceCounter(out long value);
+
+
+            [DllImport("kernel32.dll")]
+            public static extern bool QueryPerformanceFrequency(out long value);
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
@@ -44,11 +44,14 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
                 messages.AddRange(container.Messages);
 
                 if (container.End)
+                {
+                    _lookupRateLimiter.Release(); //start timer for next permission
                     res.TrySetResult(messages);
+                }
             }
 
             client.MessageReceived += SocketClientOnMessageReceived;
-            await _lookupRateLimiter.WaitAsync();
+            await _lookupRateLimiter.WaitAsync(); //ask permission to send request
             client.Send(request);
 
             await res.Task.ContinueWith(x =>

--- a/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
@@ -37,6 +37,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
 
                 if (container.ErrorMessage != null)
                 {
+                    _lookupRateLimiter.Release(); //start timer for next permission
                     res.TrySetException(_exceptionFactory.CreateNew(request, container.ErrorMessage, container.MessageTrace));
                     return;
                 }

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
@@ -25,7 +25,7 @@ namespace IQFeed.CSharpApiClient.Lookup
             // Common
             var requestFormatter = new RequestFormatter();
             var lookupDispatcher = new LookupDispatcher(host, port, bufferSize, IQFeedDefault.ProtocolVersion, numberOfClients, requestFormatter);
-            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond, requestsPerSecond, higherPrecision: false);
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond - 1, requestsPerSecond - 1, higherPrecision: false);
             var exceptionFactory = new ExceptionFactory();
             var lookupMessageFileHandler = new LookupMessageFileHandler(lookupDispatcher, exceptionFactory, timeout);
             var historicalMessageHandler = new HistoricalMessageHandler();

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
@@ -25,7 +25,7 @@ namespace IQFeed.CSharpApiClient.Lookup
             // Common
             var requestFormatter = new RequestFormatter();
             var lookupDispatcher = new LookupDispatcher(host, port, bufferSize, IQFeedDefault.ProtocolVersion, numberOfClients, requestFormatter);
-            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
+            var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond, requestsPerSecond, higherPrecision: false);
             var exceptionFactory = new ExceptionFactory();
             var lookupMessageFileHandler = new LookupMessageFileHandler(lookupDispatcher, exceptionFactory, timeout);
             var historicalMessageHandler = new HistoricalMessageHandler();

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
@@ -42,7 +42,6 @@ namespace IQFeed.CSharpApiClient.Lookup
             
             _intervalFrequency = (int)(TimeSpan.FromSeconds(1).Ticks / requestsPerSecond);
             _intervalMilliseconds = (int)new TimeSpan(_intervalFrequency).TotalMilliseconds;
-            _intervalFrequency = (int)FrequencyStopwatch.ToCurrentFrequency(_intervalFrequency);
             _frequencyStopwatch = new FrequencyStopwatch(_intervalFrequency);
             _requestsPerSecond = requestsPerSecond;
             _running = true;

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using IQFeed.CSharpApiClient.Common;
 
 namespace IQFeed.CSharpApiClient.Lookup
 {
@@ -9,79 +10,135 @@ namespace IQFeed.CSharpApiClient.Lookup
     /// Implementation of IQFeed requests rate limit
     /// http://forums.iqfeed.net/index.cfm?page=topic&topicID=5832
     /// </summary>
-    public class LookupRateLimiter : IDisposable
+    public sealed class LookupRateLimiter : IDisposable
     {
-        public TimeSpan Interval { get; }
-        public int RequestsPerSecond { get; }
-        public bool IsRunning => !_releaseTask.IsCompleted;
-
-        private readonly SemaphoreSlim _semaphoreSlim;
-        private readonly Task _releaseTask;
-        
         private bool _disposed;
-        private volatile bool _running = true;
+        private volatile bool _running;
 
-        public LookupRateLimiter(int requestsPerSecond)
+        private readonly int _intervalFrequency;
+        private readonly int _intervalMilliseconds;
+        private readonly int _requestsPerSecond;
+        private readonly SemaphoreSlim _sendPermission;
+        private readonly Timer _timer;
+        private FrequencyStopwatch _frequencyStopwatch;
+        private int _returnable;
+
+        public TimeSpan Interval => new TimeSpan(_intervalFrequency);
+
+        public int RequestsPerSecond => _requestsPerSecond;
+
+        public bool IsRunning => _running;
+
+        /// <param name="requestsPerSecond"></param>
+        /// <param name="intialPermissions"></param>
+        /// <param name="higherPrecision">
+        ///     When false, the timer will sleep a fixed amount of time without changing the paramters. this is best for high frequency per second. No heap allocations
+        ///     When true, the timer will sleep almost exactly the time remaining until next invocation, best for lower frequecy. 1 heap allocation per tick.
+        /// </param>
+        public LookupRateLimiter(int requestsPerSecond, int intialPermissions = 0, bool higherPrecision = false)
         {
-            Interval = TimeSpan.FromTicks(TimeSpan.FromSeconds(1).Ticks / requestsPerSecond);
-            RequestsPerSecond = requestsPerSecond;
+            if (intialPermissions > requestsPerSecond)
+                throw new ArgumentOutOfRangeException(nameof(intialPermissions));
+            
+            _intervalFrequency = (int)(TimeSpan.FromSeconds(1).Ticks / requestsPerSecond);
+            _intervalMilliseconds = (int)new TimeSpan(_intervalFrequency).TotalMilliseconds;
+            _intervalFrequency = (int)FrequencyStopwatch.ToCurrentFrequency(_intervalFrequency);
+            _frequencyStopwatch = new FrequencyStopwatch(_intervalFrequency);
+            _requestsPerSecond = requestsPerSecond;
+            _running = true;
 
-            _semaphoreSlim = new SemaphoreSlim(0, requestsPerSecond);
-            _releaseTask = ReleaseSemaphoreAsync(Interval, RequestsPerSecond);
-        }
-
-        public async Task WaitAsync()
-        {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-        }
-
-        private async Task ReleaseSemaphoreAsync(TimeSpan interval, int maxCount)
-        {
-            var intervalTicks = (int)interval.Ticks;
-            var remainderTicks = 0;
-            var sw = new Stopwatch();
-
-            while (_running)
+            _sendPermission = new SemaphoreSlim(intialPermissions, requestsPerSecond);
+            if (intialPermissions != requestsPerSecond)
             {
-                sw.Restart();
-                await Task.Delay(interval).ConfigureAwait(false);
-                sw.Stop();
-
-                var totalTicks = remainderTicks + (int)sw.ElapsedTicks;
-                remainderTicks = totalTicks % intervalTicks;
-                var releaseCount = totalTicks / intervalTicks;
-                var releaseCapacity = maxCount - _semaphoreSlim.CurrentCount;
-
-                if (releaseCapacity == 0 || releaseCount == 0)
-                    continue;
-
-                releaseCount = releaseCount > releaseCapacity ? releaseCapacity : releaseCount;
-                _semaphoreSlim.Release(releaseCount);
+                _returnable = requestsPerSecond - intialPermissions;
+                _frequencyStopwatch.Start();
             }
+
+            _timer = higherPrecision
+                ? new Timer(delegate(object context) { ((LookupRateLimiter)context).OnCallbackHighPrecision(); }, this, _intervalMilliseconds, -1)
+                : new Timer(delegate(object context) { ((LookupRateLimiter)context).OnCallback(); }, this, _intervalMilliseconds, _intervalMilliseconds);
+        }
+
+        public Task WaitAsync()
+        {
+            return _sendPermission.WaitAsync();
+        }
+
+        public void Release()
+        {
+            lock (_sendPermission)
+            {
+                //if stopwatch not running, start:
+                _frequencyStopwatch.Start();
+                _returnable++;
+            }
+        }
+
+        private void OnCallback()
+        {
+            if (!_running || !_frequencyStopwatch.IsRunning)
+                return;
+
+            int returnableNow;
+            lock (_sendPermission)
+            {
+                if (_returnable == 0)
+                    return;
+
+                returnableNow = Math.Min(_returnable, (int)(_frequencyStopwatch.Checkpoint() / _intervalFrequency));
+                if (returnableNow == 0)
+                    return;
+
+                _returnable -= returnableNow;
+            }
+
+            var result = _sendPermission.Release(returnableNow);
+            if (returnableNow + result == _requestsPerSecond)
+                _frequencyStopwatch.Reset();
+        }
+
+        private void OnCallbackHighPrecision()
+        {
+            if (!_running || !_frequencyStopwatch.IsRunning)
+                return;
+
+            int returnableNow;
+            lock (_sendPermission)
+            {
+                if (_returnable == 0)
+                    goto _waitNextData;
+
+                returnableNow = (int)(_frequencyStopwatch.Checkpoint() / _intervalFrequency);
+                if (returnableNow == 0)
+                    goto _waitNextData;
+
+                _returnable -= returnableNow;
+            }
+
+            var result = _sendPermission.Release(returnableNow);
+            if (returnableNow + result == _requestsPerSecond)
+            {
+                _frequencyStopwatch.Reset();
+                goto _waitNextData;
+            }
+
+            _timer.Change(Math.Max(0, _intervalMilliseconds - _frequencyStopwatch.ExcessMilliseconds), -1);
+            return;
+
+            _waitNextData:
+            _timer.Change(_intervalMilliseconds / 2, -1);
+            return;
         }
 
         public void Dispose()
         {
-            // Dispose of unmanaged resources.
-            Dispose(true);
-            // Suppress finalization.
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
             if (_disposed)
                 return;
-
-            if (disposing)
-            {
-                _running = false;
-                _releaseTask.Wait();
-
-                _semaphoreSlim?.Dispose();
-            }
-
             _disposed = true;
+
+            _running = false;
+            _timer.Dispose();
+            _sendPermission.Dispose();
         }
     }
 }


### PR DESCRIPTION
Hey @mathpaquette, I had few motivations to make this change, heres the changelog
- I replaced Task.Delay with `System.Threading.Timer` which is exactly what `Task.Delay` does behind the scenes. Just no unnecessary Task and other AsyncStateMachine internal allocations.
- Added `LookupRateLimiter.Release` method which triggers at the right point of time the StopWatch. <br> it is triggered when we received `MessageContainer.IsEnd` message.
- Replaced the `StopWatch` with a similar mechanism struct `FrequencyStopwatch` which does not loose time across the delay/timer invocation.
- `LookupRateLimiter` is constructed with 50 initial semaphore count.
- Theres a `higherPrecision` flag in `LookupRateLimiter` constructor which in will produces calls more precision at the cost of 1 additional heap allocation and some cycles. It is false by default as for frequency 50 it seems to be not enough beneficial.
- `LookupRateLimiter.WaitAsync`: removed unnecessary async keyword
- I've added ConcurrencyBenchmarkHistoricalExample which does a stress test to the lookup calls. 
- Added inevitable lock, it only performs simple cpu instructions in the locking scope

All those combined reduces the heap allocation every call and timer invocation to minimum and the throttling is more identical to IQFeeds server-side. Also propably thanks to eliminating the two unnecessary AsyncStateMachine+Task, it is also likely to be faster than previous implementation regardless to the lock.

Please kindly review and test. Note that I've ran all examples and tests in production environment.