### PR TITLE
Properly handle "invalid" symbols during Level 1 snapshot operations

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests.Integration/Streaming/Level1/Level1ClientTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests.Integration/Streaming/Level1/Level1ClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using IQFeed.CSharpApiClient.Common.Exceptions;
 using IQFeed.CSharpApiClient.Streaming.Level1;
 using NUnit.Framework;
 
@@ -7,6 +8,7 @@ namespace IQFeed.CSharpApiClient.Tests.Integration.Streaming.Level1
     public class Level1ClientTests
     {
         private const string Symbol = "AAPL";
+        private const string NotFoundSymbol = "NotFoundSymbol";
         private ILevel1Client _level1Client;
 
         public Level1ClientTests()
@@ -45,6 +47,20 @@ namespace IQFeed.CSharpApiClient.Tests.Integration.Streaming.Level1
 
             // Assert
             Assert.AreEqual(updateSummaryMessage.Symbol, Symbol);
+        }
+
+        [Test]
+        public void Should_Throw_Exceptions_When_SymbolNotFound_FundamentalSnapshot()
+        {
+            // Assert
+            Assert.ThrowsAsync<SymbolNotFoundIQFeedException>(async () => await _level1Client.GetFundamentalSnapshotAsync(NotFoundSymbol));
+        }
+
+        [Test]
+        public void Should_Throw_Exceptions_When_SymbolNotFound_For_UpdateSummarySnapshot()
+        {
+            // Assert
+            Assert.ThrowsAsync<SymbolNotFoundIQFeedException>(async () => await _level1Client.GetUpdateSummarySnapshotAsync(NotFoundSymbol));
         }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
+++ b/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
@@ -3,6 +3,6 @@
     // ReSharper disable once InconsistentNaming
     public class SymbolNotFoundIQFeedException : IQFeedException
     {
-        public SymbolNotFoundIQFeedException(string symbol) : base(string.Empty, $"The specified Symbol '{symbol}' wasn't found on IQFeed.", string.Empty, string.Empty) { }
+        public SymbolNotFoundIQFeedException(string request, string symbol) : base(request, $"The specified Symbol '{symbol}' wasn't found on IQFeed.", string.Empty, string.Empty) { }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
+++ b/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
@@ -1,0 +1,8 @@
+﻿namespace IQFeed.CSharpApiClient.Common.Exceptions
+{
+    // ReSharper disable once InconsistentNaming
+    public class SymbolNotFoundIQFeedException : IQFeedException
+    {
+        public SymbolNotFoundIQFeedException(string symbol) : base(string.Empty, $"The specified Symbol '{symbol}' wasn't found on IQFeed.", string.Empty, string.Empty) { }
+    }
+}

--- a/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
+++ b/src/IQFeed.CSharpApiClient/Common/Exceptions/SymbolNotFoundIQFeedException.cs
@@ -1,8 +1,0 @@
-﻿namespace IQFeed.CSharpApiClient.Common.Exceptions
-{
-    // ReSharper disable once InconsistentNaming
-    public class SymbolNotFoundIQFeedException : IQFeedException
-    {
-        public SymbolNotFoundIQFeedException(string symbol) : base(string.Empty, $"The specified Symbol '{symbol}' wasn't found on IQFeed.", string.Empty, string.Empty) { }
-    }
-}

--- a/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1Snapshot.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level1/Level1Snapshot.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using IQFeed.CSharpApiClient.Common.Exceptions;
 using IQFeed.CSharpApiClient.Extensions;
 using IQFeed.CSharpApiClient.Socket;
-using IQFeed.CSharpApiClient.Streaming.Common.Messages;
 using IQFeed.CSharpApiClient.Streaming.Level1.Handlers;
 using IQFeed.CSharpApiClient.Streaming.Level1.Messages;
 
@@ -61,20 +59,12 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
                     res.TrySetResult(fundamentalMessage);
             }
 
-            void Level1ClientOnSymbolNotFound(SymbolNotFoundMessage symbolNotFoundMessage)
-            {
-                if (symbolNotFoundMessage.Symbol == symbol)
-                    res.TrySetException(new SymbolNotFoundIQFeedException(symbol));
-            }
-
             _level1MessageHandler.Fundamental += Level1ClientOnFundamental;
-            _level1MessageHandler.SymbolNotFound += Level1ClientOnSymbolNotFound;
             ReqWatch(symbol);
 
             await res.Task.ContinueWith(x =>
             {
                 _level1MessageHandler.Fundamental -= Level1ClientOnFundamental;
-                _level1MessageHandler.SymbolNotFound -= Level1ClientOnSymbolNotFound;
                 ReqUnwatch(symbol);
                 ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);
@@ -94,22 +84,14 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1
                     res.TrySetResult(updateSummaryMessage);
             }
 
-            void Level1ClientOnSymbolNotFound(SymbolNotFoundMessage symbolNotFoundMessage)
-            {
-                if (symbolNotFoundMessage.Symbol == symbol)
-                    res.TrySetException(new SymbolNotFoundIQFeedException(symbol));
-            }
-
             _level1MessageHandler.Summary += Level1ClientOnUpdate;
             _level1MessageHandler.Update += Level1ClientOnUpdate;
-            _level1MessageHandler.SymbolNotFound += Level1ClientOnSymbolNotFound;
             ReqWatch(symbol);
 
             await res.Task.ContinueWith(x =>
             {
                 _level1MessageHandler.Summary -= Level1ClientOnUpdate;
                 _level1MessageHandler.Update -= Level1ClientOnUpdate;
-                _level1MessageHandler.SymbolNotFound -= Level1ClientOnSymbolNotFound;
                 ReqUnwatch(symbol);
                 ct.Dispose();
             }, TaskContinuationOptions.None).ConfigureAwait(false);


### PR DESCRIPTION
Added logic to handle invalid symbol snapshot queries to fail fast and with a proper exception rather than a timeout.