### PR TITLE
Barcreatation bug

### DIFF
--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
@@ -43,7 +43,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
         {
             var intervalTicks = interval.Ticks;
             DateTime? nextTimestamp = null;
-            DateTime? currentBarDate = null;
+            DateTime? currentDate = null;
             HistoricalBar currentBar = null;
 
             var totalVolume = 0;
@@ -68,14 +68,14 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
 
                 // Check for date change up here otherwise 'O' ticks will be ignored
                 //   if they are the first ticks of the day, which will make total volume incorrect
-                if (currentBarDate != null && tick.Timestamp.Date != currentBarDate)
+                if (currentDate != null && tick.Timestamp.Date != currentDate)
                 {
                     // Date has changed. Reset the numbers for the next one
                     // Don't start a new bar here, because if the next tick is an 'O' we want to count the volume
                     //  but not the tick, and if it's the only tick in a bar, then there shouldn't be a bar! (Apparently)
                     totalVolume = 0;
                     totalTrade = 0;
-                    currentBarDate = tick.Timestamp.Date;
+                    currentDate = tick.Timestamp.Date;
                 }
 
                 totalVolume += tick.LastSize;
@@ -101,7 +101,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
                         0,
                         tick.Last * tick.LastSize);
                     nextTimestamp = currentTimestamp.AddTicks(intervalTicks);
-                    currentBarDate = currentTimestamp.Date;
+                    currentDate = currentTimestamp.Date;
                 }
 
                 if (tick.Last < currentBar.Low)

--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
@@ -75,6 +75,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
                     //  but not the tick, and if it's the only tick in a bar, then there shouldn't be a bar! (Apparently)
                     totalVolume = 0;
                     totalTrade = 0;
+                    currentBarDate = tick.Timestamp.Date;
                 }
 
                 totalVolume += tick.LastSize;

--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/Resample/TickMessageExtensions.cs
@@ -54,6 +54,32 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
                 if (tick.LastSize == 0)
                     continue;
 
+                // Nich - check for date change up here otherwise 'O' ticks will be ignored
+                //   if they are the first ticks of the day, which will make total volume incorrect
+                if (currentBar != null && tick.Timestamp.Date != currentBar.Timestamp.Date)
+                {
+                    // Date has changed. Send out the current bar, and then reset the numbers for the next one
+                    currentBar.VWAP = currentBar.VWAP / currentBar.PeriodVolume;
+                    yield return currentBar;
+
+                    // Don't start a new bar here, because if the next tick is an 'O' we want to count the volume
+                    //  but not the tick, and if it's the only tick in a bar, then there shouldn't be a bar! (Apparently)
+                    totalVolume = 0;
+                    totalTrade = 0;
+
+                    currentBar = null;
+                }
+
+                if (currentBar != null && tick.Timestamp >= nextTimestamp)
+                {
+                    // We've reached the end of this bar. Send it out! Setting the currentBar to null
+                    //   will cause a new bar to be generated on the first valid tick, below.
+                    currentBar.VWAP = currentBar.VWAP / currentBar.PeriodVolume;
+                    yield return currentBar;
+
+                    currentBar = null;
+                }
+
                 totalVolume += tick.LastSize;
                 totalTrade += 1;
 
@@ -61,53 +87,39 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical.Resample
                 if (tick.BasisForLast == 'O')
                     continue;
 
-                if (tick.Timestamp < nextTimestamp)
+                if (currentBar == null)
                 {
-                    if (tick.Last < currentBar.Low)
-                        currentBar.Low = tick.Last;
-
-                    if (tick.Last > currentBar.High)
-                        currentBar.High = tick.Last;
-
-                    currentBar.Close = tick.Last;
-
-                    currentBar.PeriodVolume += tick.LastSize;
-                    currentBar.PeriodTrade += 1;
-
-                    currentBar.TotalVolume = totalVolume;
-                    currentBar.TotalTrade = totalTrade;
-
-                    currentBar.VWAP += tick.Last * tick.LastSize;
-                    continue;
+                    // if we get here, we have a valid trade tick, and we need a new bar
+                    var currentTimestamp = tick.Timestamp.Trim(intervalTicks);
+                    currentBar = new HistoricalBar(
+                        currentTimestamp,
+                        tick.Last,
+                        tick.Last,
+                        tick.Last,
+                        tick.Last,
+                        0,
+                        0,
+                        0,
+                        0,
+                        tick.Last * tick.LastSize);
+                    nextTimestamp = currentTimestamp.AddTicks(intervalTicks);
                 }
 
-                if (currentBar != null)
-                {
-                    // reset the counts if dates differ
-                    if (tick.Timestamp.Date != currentBar.Timestamp.Date)
-                    {
-                        totalVolume = tick.LastSize;
-                        totalTrade = 1;
-                    }
+                if (tick.Last < currentBar.Low)
+                    currentBar.Low = tick.Last;
 
-                    currentBar.VWAP = currentBar.VWAP / currentBar.PeriodVolume;
-                    yield return currentBar;
-                }
+                if (tick.Last > currentBar.High)
+                    currentBar.High = tick.Last;
 
-                var currentTimestamp = tick.Timestamp.Trim(intervalTicks);
-                nextTimestamp = currentTimestamp.AddTicks(intervalTicks);
+                currentBar.Close = tick.Last;
 
-                currentBar = new HistoricalBar(
-                    currentTimestamp,
-                    tick.Last,
-                    tick.Last,
-                    tick.Last,
-                    tick.Last,
-                    totalVolume,
-                    tick.LastSize,
-                    totalTrade,
-                    1,
-                    tick.Last * tick.LastSize);
+                currentBar.PeriodVolume += tick.LastSize;
+                currentBar.PeriodTrade += 1;
+
+                currentBar.TotalVolume = totalVolume;
+                currentBar.TotalTrade = totalTrade;
+
+                currentBar.VWAP += tick.Last * tick.LastSize;
             }
 
             // return the last created bar when last tick reached


### PR DESCRIPTION
@mathpaquette 

OK, I found and fixed the bar problem.

There was an edge case, where if at the beginning of a day there were several 'O' ticks, they were just disgarded, whereas actually the volume should have been counted in TotalVolume to match the interval data downloaded from IQ.

I re-wrote the bar conversion algo slightly to make this happen, and commented my changes.

The test now passes both on the master branch, and also when applied to the 6.1 branch, so if you apply this fix, then I can rebase protocol_6.1_new and we should be good to go! :) 