### PR TITLE
fix(lookup): adjust semaphore count to reduce initial burst of requests

### DIFF
--- a/src/IQFeed.CSharpApiClient/IQFeed.CSharpApiClient.csproj
+++ b/src/IQFeed.CSharpApiClient/IQFeed.CSharpApiClient.csproj
@@ -19,7 +19,7 @@
         <Version>1.0.0</Version>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+      <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
       <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupFacade.cs
@@ -48,7 +48,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
             }
 
             client.MessageReceived += SocketClientOnMessageReceived;
-            await _lookupRateLimiter.WaitAsync();
+            await _lookupRateLimiter.WaitAsync().ConfigureAwait(false);
             client.Send(request);
 
             await res.Task.ContinueWith(x =>

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupClientFactory.cs
@@ -27,7 +27,7 @@ namespace IQFeed.CSharpApiClient.Lookup
             var lookupDispatcher = new LookupDispatcher(host, port, bufferSize, IQFeedDefault.ProtocolVersion, numberOfClients, requestFormatter);
             var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
             var exceptionFactory = new ExceptionFactory();
-            var lookupMessageFileHandler = new LookupMessageFileHandler(lookupDispatcher, exceptionFactory, timeout);
+            var lookupMessageFileHandler = new LookupMessageFileHandler(lookupDispatcher, lookupRateLimiter, exceptionFactory, timeout);
             var historicalMessageHandler = new HistoricalMessageHandler();
 
             // Historical
@@ -48,8 +48,8 @@ namespace IQFeed.CSharpApiClient.Lookup
                 new NewsRequestFormatter(),
                 lookupDispatcher,
                 lookupRateLimiter,
-                exceptionFactory, 
-                new NewsMessageHandler(), 
+                exceptionFactory,
+                new NewsMessageHandler(),
                 timeout);
 
             // Symbol
@@ -61,16 +61,16 @@ namespace IQFeed.CSharpApiClient.Lookup
                 new SymbolMessageHandler(),
                 new MarketSymbolReader(),
                 new ExpiredOptionReader(),
-                new FileDownloader(new LocalCacheStrategy()), 
+                new FileDownloader(new LocalCacheStrategy()),
                 timeout);
 
             // Chains
             var chainsFacade = new ChainsFacade(
                 new ChainsRequestFormatter(),
                 new ChainsMessageHandler(),
-                lookupDispatcher, 
+                lookupDispatcher,
                 lookupRateLimiter,
-                exceptionFactory, 
+                exceptionFactory,
                 timeout);
 
             return new LookupClient(lookupDispatcher, historicalFacade, newsFacade, symbolFacade, chainsFacade);

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupDefault.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupDefault.cs
@@ -21,6 +21,8 @@ namespace IQFeed.CSharpApiClient.Lookup
 
         /// <summary>
         /// Default requests per second allowed by IQFeed
+        /// IQFeed can tolerate very short burst around 75 requests/second.
+        /// <see cref="LookupRateLimiter"/> and corresponding tests for more info.
         /// </summary>
         public const int RequestsPerSecond = 50;
     }


### PR DESCRIPTION
Basically, by setting the semaphore half the size of the RequestsPerSecond limit, this allow us to reduce the initial burst of requests. That way, IQFeed is happy and we dont have to tweak anything else.

Fixes #106
Fixes #108