### PR TITLE
Fix for Issue #119 - protocol 6.1 new fields missing from new Dynamic Message interface/object

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
@@ -190,9 +190,9 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             var emptyInstance1 = Activator.CreateInstance(updateSummaryMessageType) as IUpdateSummaryMessage;
             var emptyInstance2 = Activator.CreateInstance(updateSummaryMessageType) as IUpdateSummaryMessage;
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance1 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",1 });
-            var parsedInstance2 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",1 });
-            var parsedInstance3 = parseMethod.Invoke(null, new object[] { "P,AAPL,200,52500,03/30/2021,19:59:14.503633",2 });
+            var parsedInstance1 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633,1" });
+            var parsedInstance2 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633,1" });
+            var parsedInstance3 = parseMethod.Invoke(null, new object[] { "P,AAPL,200,52500,03/30/2021,19:59:14.503633,1" });
 
             // Assert
             Assert.AreEqual(emptyInstance1, emptyInstance2);
@@ -210,7 +210,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             // Act
             var emptyInstance = Activator.CreateInstance(updateSummaryMessageType);
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",2 });
+            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633,2" });
 
             // calculate the expected hashes
             var expectedHashCodeEmptyInstance = 17;

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
@@ -135,6 +135,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             Assert.AreEqual(default(TimeSpan), typedEmptyInstance.MostRecentTradeTime);
             Assert.AreEqual(default(int), typedEmptyInstance.MostRecentTradeAggressor);
             Assert.Throws(typeof(NotImplementedException), () => typedEmptyInstance.Bid.ToString());
+            Assert.Throws(typeof(NotImplementedException), () => typedEmptyInstance.MostRecentTradeDayCode.ToString());
         }
 
         [Test]

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level1/Dynamic/Messages/UpdateSummaryDynamicMessageTypesFactoryTests.cs
@@ -20,6 +20,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             DynamicFieldset.MostRecentTradeSize,
             DynamicFieldset.MostRecentTradeDate,
             DynamicFieldset.MostRecentTradeTime,
+            DynamicFieldset.MostRecentTradeAggressor
         };
 
         private static readonly DynamicFieldset[] AllFields = new DynamicFieldset[]
@@ -67,8 +68,10 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             DynamicFieldset.MarketOpen,
             DynamicFieldset.MessageContents,
             DynamicFieldset.MostRecentTrade,
+            DynamicFieldset.MostRecentTradeAggressor,
             DynamicFieldset.MostRecentTradeConditions,
             DynamicFieldset.MostRecentTradeDate,
+            DynamicFieldset.MostRecentTradeDayCode,
             DynamicFieldset.MostRecentTradeMarketCenter,
             DynamicFieldset.MostRecentTradeSize,
             DynamicFieldset.MostRecentTradeTime,
@@ -130,6 +133,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             Assert.AreEqual(default(int), typedEmptyInstance.MostRecentTradeSize);
             Assert.AreEqual(default(DateTime), typedEmptyInstance.MostRecentTradeDate);
             Assert.AreEqual(default(TimeSpan), typedEmptyInstance.MostRecentTradeTime);
+            Assert.AreEqual(default(int), typedEmptyInstance.MostRecentTradeAggressor);
             Assert.Throws(typeof(NotImplementedException), () => typedEmptyInstance.Bid.ToString());
         }
 
@@ -151,6 +155,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             Assert.AreEqual(default(int), typedEmptyInstance.MostRecentTradeSize);
             Assert.AreEqual(default(DateTime), typedEmptyInstance.MostRecentTradeDate);
             Assert.AreEqual(default(TimeSpan), typedEmptyInstance.MostRecentTradeTime);
+            Assert.AreEqual(default(int), typedEmptyInstance.MostRecentTradeAggressor);
         }
 
         [Test]
@@ -161,7 +166,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
 
             // Act
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633" });
+            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633,3" });
             var typedParsedInstance = parsedInstance as IUpdateSummaryDynamicMessage;
 
             // Assert
@@ -172,6 +177,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             Assert.AreEqual(52500, typedParsedInstance.MostRecentTradeSize);
             Assert.AreEqual(FieldParser.ParseDate("03/30/2021", FundamentalMessage.FundamentalDateTimeFormat), typedParsedInstance.MostRecentTradeDate);
             Assert.AreEqual(FieldParser.ParseTime("19:59:14.503633", UpdateSummaryMessage.UpdateMessageTimeFormat), typedParsedInstance.MostRecentTradeTime);
+            Assert.AreEqual(3, typedParsedInstance.MostRecentTradeAggressor);
         }
 
         [Test]
@@ -184,9 +190,9 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             var emptyInstance1 = Activator.CreateInstance(updateSummaryMessageType) as IUpdateSummaryMessage;
             var emptyInstance2 = Activator.CreateInstance(updateSummaryMessageType) as IUpdateSummaryMessage;
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance1 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633" });
-            var parsedInstance2 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633" });
-            var parsedInstance3 = parseMethod.Invoke(null, new object[] { "P,AAPL,200,52500,03/30/2021,19:59:14.503633" });
+            var parsedInstance1 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",1 });
+            var parsedInstance2 = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",1 });
+            var parsedInstance3 = parseMethod.Invoke(null, new object[] { "P,AAPL,200,52500,03/30/2021,19:59:14.503633",2 });
 
             // Assert
             Assert.AreEqual(emptyInstance1, emptyInstance2);
@@ -204,7 +210,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             // Act
             var emptyInstance = Activator.CreateInstance(updateSummaryMessageType);
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633" });
+            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633",2 });
 
             // calculate the expected hashes
             var expectedHashCodeEmptyInstance = 17;
@@ -213,6 +219,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             expectedHashCodeEmptyInstance = expectedHashCodeEmptyInstance * 29 + default(int).GetHashCode();
             expectedHashCodeEmptyInstance = expectedHashCodeEmptyInstance * 29 + default(DateTime).GetHashCode();
             expectedHashCodeEmptyInstance = expectedHashCodeEmptyInstance * 29 + default(TimeSpan).GetHashCode();
+            expectedHashCodeEmptyInstance = expectedHashCodeEmptyInstance * 29 + default(int).GetHashCode();
 
             var expectedHashCodeParsedInstance = 17;
             expectedHashCodeParsedInstance = expectedHashCodeParsedInstance * 29 + "AAPL".GetHashCode();
@@ -220,6 +227,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             expectedHashCodeParsedInstance = expectedHashCodeParsedInstance * 29 + 52500.GetHashCode();
             expectedHashCodeParsedInstance = expectedHashCodeParsedInstance * 29 + FieldParser.ParseDate("03/30/2021", FundamentalMessage.FundamentalDateTimeFormat).GetHashCode();
             expectedHashCodeParsedInstance = expectedHashCodeParsedInstance * 29 + FieldParser.ParseTime("19:59:14.503633", UpdateSummaryMessage.UpdateMessageTimeFormat).GetHashCode();
+            expectedHashCodeParsedInstance = expectedHashCodeParsedInstance * 29 + 2.GetHashCode();
 
             // Assert
             Assert.IsNotNull(emptyInstance);
@@ -237,15 +245,17 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
             // Act
             var emptyInstance = Activator.CreateInstance(updateSummaryMessageType);
             var parseMethod = updateSummaryMessageType.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633" });
+            var parsedInstance = parseMethod.Invoke(null, new object[] { "P,AAPL,188.3500,52500,03/30/2021,19:59:14.503633,2" });
 
             // generate the expected string values
             var expectedStringEmptyInstance = $"Symbol: <NULL>, MostRecentTrade: {default(double)}, MostRecentTradeSize: {default(int)}, " +
                 $"MostRecentTradeDate: {default(DateTime)}, " +
-                $"MostRecentTradeTime: {default(TimeSpan)}";
+                $"MostRecentTradeTime: {default(TimeSpan)}, " +
+                $"MostRecentTradeAggressor: {default(int)}";
             var expectedStringParsedInstance = $"Symbol: AAPL, MostRecentTrade: 188.35, MostRecentTradeSize: 52500, " +
                 $"MostRecentTradeDate: {FieldParser.ParseDate("03/30/2021", FundamentalMessage.FundamentalDateTimeFormat)}, " +
-                $"MostRecentTradeTime: {FieldParser.ParseTime("19:59:14.503633", UpdateSummaryMessage.UpdateMessageTimeFormat)}";
+                $"MostRecentTradeTime: {FieldParser.ParseTime("19:59:14.503633", UpdateSummaryMessage.UpdateMessageTimeFormat)}, " +
+                $"MostRecentTradeAggressor: 2";
 
             // Assert
             Assert.IsNotNull(emptyInstance);            
@@ -267,6 +277,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
                 DynamicFieldset.MostRecentTradeSize,
                 DynamicFieldset.MostRecentTradeDate,
                 DynamicFieldset.MostRecentTradeTime,
+                DynamicFieldset.MostRecentTradeAggressor
             });
             // same fields, different order
             var updateSummaryMessageType3 = UpdateSummaryDynamicMessageTypesFactory.GenerateDynamicObjectType(new DynamicFieldset[]
@@ -274,6 +285,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level1.Dynamic.Messages
                 DynamicFieldset.Symbol,
                 DynamicFieldset.MostRecentTrade,
                 DynamicFieldset.MostRecentTradeSize,
+                DynamicFieldset.MostRecentTradeAggressor,
                 DynamicFieldset.MostRecentTradeTime,
                 DynamicFieldset.MostRecentTradeDate,
             });

--- a/src/IQFeed.CSharpApiClient/Streaming/Level1/Dynamic/Messages/IUpdateSummaryDynamicMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level1/Dynamic/Messages/IUpdateSummaryDynamicMessage.cs
@@ -73,5 +73,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1.Dynamic.Messages
         string Type { get; }
         double Volatility { get; }
         double VWAP { get; }
+        int MostRecentTradeAggressor { get; }
+        int MostRecentTradeDayCode { get; }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Streaming/Level1/Dynamic/Messages/IUpdateSummaryDynamicMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level1/Dynamic/Messages/IUpdateSummaryDynamicMessage.cs
@@ -4,33 +4,22 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1.Dynamic.Messages
 {
     public interface IUpdateSummaryDynamicMessage
     {
-        string Symbol { get; }
-        double MostRecentTrade { get; }
-        int MostRecentTradeSize { get; }
-        TimeSpan MostRecentTradeTime { get; }
-        int MostRecentTradeMarketCenter { get; }
-        int TotalVolume { get; }
-        double Bid { get; }
-        int BidSize { get; }
-        double Ask { get; }
-        int AskSize { get; }
-        double Open { get; }
-        double High { get; }
-        double Low { get; }
-        double Close { get; }
-        string MessageContents { get; }
-        string MostRecentTradeConditions { get; }
         double SevenDayYield { get; }
+        double Ask { get; }
         double AskChange { get; }
         int AskMarketCenter { get; }
+        int AskSize { get; }
         TimeSpan AskTime { get; }
         string AvailableRegions { get; }
         double AverageMaturity { get; }
+        double Bid { get; }
         double BidChange { get; }
         int BidMarketCenter { get; }
+        int BidSize { get; }
         TimeSpan BidTime { get; }
         double Change { get; }
         double ChangeFromOpen { get; }
+        double Close { get; }
         double CloseRange1 { get; }
         double CloseRange2 { get; }
         string DaysToExpiration { get; }
@@ -46,16 +35,27 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1.Dynamic.Messages
         double ExtendedTradingDifference { get; }
         string FinancialStatusIndicator { get; }
         string FractionDisplayCode { get; }
+        double High { get; }
         double Last { get; }
         DateTime LastDate { get; }
         int LastMarketCenter { get; }
         int LastSize { get; }
         TimeSpan LastTime { get; }
+        double Low { get; }
         double MarketCapitalization { get; }
         int MarketOpen { get; }
+        string MessageContents { get; }
+        double MostRecentTrade { get; }
+        int MostRecentTradeAggressor { get; }
+        string MostRecentTradeConditions { get; }
         DateTime MostRecentTradeDate { get; }
+        int MostRecentTradeDayCode { get; }
+        int MostRecentTradeMarketCenter { get; }
+        int MostRecentTradeSize { get; }
+        TimeSpan MostRecentTradeTime { get; }
         double NetAssetValue { get; }
         int NumberOfTradesToday { get; }
+        double Open { get; }
         int OpenInterest { get; }
         double OpenRange1 { get; }
         double OpenRange2 { get; }
@@ -68,12 +68,12 @@ namespace IQFeed.CSharpApiClient.Streaming.Level1.Dynamic.Messages
         double Settle { get; }
         DateTime SettlementDate { get; }
         double Spread { get; }
+        string Symbol { get; }
         int Tick { get; }
         int TickID { get; }
+        int TotalVolume { get; }
         string Type { get; }
         double Volatility { get; }
         double VWAP { get; }
-        int MostRecentTradeAggressor { get; }
-        int MostRecentTradeDayCode { get; }
     }
 }


### PR DESCRIPTION
Added fields to interface, and updated tests appropriately (this time) :)

Relates to issue #119 