### PR TITLE
fix(lookup): properly throw for InvalidData

### DIFF
--- a/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/HistoricalBar.cs
+++ b/src/IQFeed.CSharpApiClient.Extensions/Lookup/Historical/HistoricalBar.cs
@@ -18,7 +18,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
             double open,
             double close,
             long totalVolume,
-            int periodVolume,
+            long periodVolume,
             int totalTrade,
             int periodTrade,
             double vwap)
@@ -41,7 +41,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
         public double Open { get; set; }
         public double Close { get; set; }
         public long TotalVolume { get; set; }
-        public int PeriodVolume { get; set; }
+        public long PeriodVolume { get; set; }
         public int TotalTrade { get; set; }
         public int PeriodTrade { get; set; }
         public double VWAP { get; set; }
@@ -57,7 +57,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
                 double.Parse(values[3], CultureInfo.InvariantCulture),
                 double.Parse(values[4], CultureInfo.InvariantCulture),
                 long.Parse(values[5], CultureInfo.InvariantCulture),
-                int.Parse(values[6], CultureInfo.InvariantCulture),
+                long.Parse(values[6], CultureInfo.InvariantCulture),
                 int.Parse(values[7], CultureInfo.InvariantCulture),
                 int.Parse(values[8], CultureInfo.InvariantCulture),
             double.Parse(values[9], CultureInfo.InvariantCulture));
@@ -110,7 +110,7 @@ namespace IQFeed.CSharpApiClient.Extensions.Lookup.Historical
                 hashCode = (hashCode * 397) ^ Open.GetHashCode();
                 hashCode = (hashCode * 397) ^ Close.GetHashCode();
                 hashCode = (hashCode * 397) ^ TotalVolume.GetHashCode();
-                hashCode = (hashCode * 397) ^ PeriodVolume;
+                hashCode = (hashCode * 397) ^ PeriodVolume.GetHashCode();
                 hashCode = (hashCode * 397) ^ TotalTrade;
                 hashCode = (hashCode * 397) ^ PeriodTrade;
                 hashCode = (hashCode * 397) ^ VWAP.GetHashCode();

--- a/src/IQFeed.CSharpApiClient.Tests/Common/ExceptionFactoryTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Common/ExceptionFactoryTests.cs
@@ -1,5 +1,8 @@
-﻿using IQFeed.CSharpApiClient.Common;
+﻿using System;
+using System.Collections.Generic;
+using IQFeed.CSharpApiClient.Common;
 using IQFeed.CSharpApiClient.Common.Exceptions;
+using IQFeed.CSharpApiClient.Lookup.Historical.Messages;
 using NUnit.Framework;
 
 namespace IQFeed.CSharpApiClient.Tests.Common
@@ -18,13 +21,15 @@ namespace IQFeed.CSharpApiClient.Tests.Common
         {
             // Arrange
             var request = "request";
-            var messageTrace = "message trace";
+            var intervalMessage = new IntervalMessage(new DateTime(2000, 01, 01, 9, 30, 00), 1, 1, 1, 1, 1, 1, 0);
+            var invalidMessages = new List<InvalidMessage<IntervalMessage>>() { new InvalidMessage<IntervalMessage>(intervalMessage, intervalMessage.ToCsv()) };
+            var messages = new List<IntervalMessage>() { intervalMessage };
 
             // Act
-            var exception = _exceptionFactory.CreateNew(request, InvalidDataIQFeedException.InvalidData, messageTrace);
+            var exception = _exceptionFactory.CreateNew(request, invalidMessages, messages);
 
             // Assert
-            var expectedException = new InvalidDataIQFeedException(request, InvalidDataIQFeedException.InvalidData, messageTrace);
+            var expectedException = new InvalidDataIQFeedException<IntervalMessage>(request, invalidMessages, messages);
             Assert.AreEqual(exception, expectedException);
         }
     }

--- a/src/IQFeed.CSharpApiClient.Tests/Lookup/Common/BaseLookupMessageHandlerTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Lookup/Common/BaseLookupMessageHandlerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using IQFeed.CSharpApiClient.Common.Exceptions;
+using System.Linq;
 using IQFeed.CSharpApiClient.Lookup.Historical;
 using IQFeed.CSharpApiClient.Tests.Common;
 using NSubstitute;
@@ -107,9 +107,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup.Common
             var container = _baseLookupMessageHandlerTestClass.ProcessMessages(HistoricalMessageHandler.TryParseTick, _errorParserFunc, messagesBytes, messagesBytes.Length);
 
             // Assert
-            Assert.AreEqual(container.End, true);
-            Assert.AreEqual(container.ErrorMessage, InvalidDataIQFeedException.InvalidData);
-            Assert.AreEqual(container.MessageTrace, message);
+            Assert.GreaterOrEqual(container.InvalidMessages.Count(), 1);
         }
 
         private class NoErrorMessageTestDataSource : IEnumerable
@@ -124,6 +122,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup.Common
                 yield return new[] { "X,,", "!ENDMSG!," };
             }
         }
+
         [TestCaseSource(typeof(NoErrorMessageTestDataSource))]
         public void Should_Return_Empty_Error_Message_When_Parsing_Messages(string[] messages)
         {

--- a/src/IQFeed.CSharpApiClient.Tests/Lookup/Historical/Messages/IntervalMessageTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Lookup/Historical/Messages/IntervalMessageTests.cs
@@ -63,7 +63,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup.Historical.Messages
         public void Should_TryParse_Return_False_When_Invalid_Data_Overflow()
         {
             // Act
-            var parsed = IntervalMessage.TryParse($"2018-06-29 16:12:40,185.2500,185.2600,185.2700,185.2800,0,{long.MaxValue},0,", out _);
+            var parsed = IntervalMessage.TryParse($"2018-06-29 16:12:40,185.2500,185.2600,185.2700,185.2800,0,0,{long.MaxValue},", out _);
 
             // Assert
             Assert.IsFalse(parsed);

--- a/src/IQFeed.CSharpApiClient/Common/ExceptionFactory.cs
+++ b/src/IQFeed.CSharpApiClient/Common/ExceptionFactory.cs
@@ -1,4 +1,5 @@
-﻿using IQFeed.CSharpApiClient.Common.Exceptions;
+﻿using System.Collections.Generic;
+using IQFeed.CSharpApiClient.Common.Exceptions;
 
 namespace IQFeed.CSharpApiClient.Common
 {
@@ -12,11 +13,14 @@ namespace IQFeed.CSharpApiClient.Common
             {
                 case IQFeedDefault.ProtocolNoDataCharacters:
                     return new NoDataIQFeedException(request, errorMessage, messageTrace);
-                case InvalidDataIQFeedException.InvalidData:
-                    return new InvalidDataIQFeedException(request, errorMessage, messageTrace);
                 default:
                     return new IQFeedException(request, DefaultMessage, errorMessage, messageTrace);
             }
+        }
+
+        public InvalidDataIQFeedException<T> CreateNew<T>(string request, IEnumerable<InvalidMessage<T>> invalidMessages, IEnumerable<T> messages)
+        {
+            return new InvalidDataIQFeedException<T>(request, invalidMessages, messages);
         }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Common/Exceptions/InvalidDataIQFeedException.cs
+++ b/src/IQFeed.CSharpApiClient/Common/Exceptions/InvalidDataIQFeedException.cs
@@ -1,11 +1,18 @@
-﻿namespace IQFeed.CSharpApiClient.Common.Exceptions
+﻿using System.Collections.Generic;
+
+namespace IQFeed.CSharpApiClient.Common.Exceptions
 {
     // ReSharper disable once InconsistentNaming
-    public class InvalidDataIQFeedException : IQFeedException
+    public class InvalidDataIQFeedException<T> : IQFeedException
     {
-        public const string InvalidData = "Invalid data";
-        private const string InvalidDataMessage = "Unable to parse received data.";
+        public IEnumerable<InvalidMessage<T>> InvalidMessages { get; }
+        public IEnumerable<T> Messages { get; }
 
-        public InvalidDataIQFeedException(string request, string errorMessage, string messageTrace) : base(request, InvalidDataMessage, errorMessage, messageTrace) { }
+        public InvalidDataIQFeedException(string request, IEnumerable<InvalidMessage<T>> invalidMessages, IEnumerable<T> messages) : 
+            base(request, "Unable to parse received data.", "Invalid data", $"Please check ${nameof(InvalidMessages)} property.")
+        {
+            InvalidMessages = invalidMessages;
+            Messages = messages;
+        }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Common/InvalidMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Common/InvalidMessage.cs
@@ -1,0 +1,19 @@
+﻿namespace IQFeed.CSharpApiClient.Common
+{
+    public class InvalidMessage<T>
+    {
+        public T Message { get; }
+        public string Data { get; }
+
+        public InvalidMessage(T message, string data)
+        {
+            Message = message;
+            Data = data;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Message)}: {Message}, {nameof(Data)}: {Data}";
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient/Common/MessageContainer.cs
+++ b/src/IQFeed.CSharpApiClient/Common/MessageContainer.cs
@@ -5,6 +5,7 @@ namespace IQFeed.CSharpApiClient.Common
     public class MessageContainer<T>
     {
         public IEnumerable<T> Messages { get; }
+        public IEnumerable<InvalidMessage<T>> InvalidMessages { get; }
         public bool End { get; }
         public string ErrorMessage { get; }
         public string MessageTrace { get; }
@@ -12,13 +13,22 @@ namespace IQFeed.CSharpApiClient.Common
         public MessageContainer(IEnumerable<T> messages, bool end)
         {
             Messages = messages;
+            InvalidMessages = new List<InvalidMessage<T>>();
             End = end;
         }
 
-        public MessageContainer(IEnumerable<T> messages, bool end, string errorMessage, string messageTrace)
+        public MessageContainer(IEnumerable<T> messages, IEnumerable<InvalidMessage<T>> invalidMessages, bool end)
         {
             Messages = messages;
+            InvalidMessages = invalidMessages;
             End = end;
+        }
+
+        public MessageContainer(string errorMessage, string messageTrace)
+        {
+            Messages = new List<T>();
+            InvalidMessages = new List<InvalidMessage<T>>();
+            End = true;
             ErrorMessage = errorMessage;
             MessageTrace = messageTrace;
         }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/DailyWeeklyMonthlyMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/DailyWeeklyMonthlyMessage.cs
@@ -47,7 +47,6 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
 
         public static bool TryParse(string message, out DailyWeeklyMonthlyMessage dailyWeeklyMonthlyMessage)
         {
-            dailyWeeklyMonthlyMessage = default;
             DateTime timestamp = default;
             double high = default;
             double low = default;
@@ -58,19 +57,16 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
 
             var values = message.SplitFeedMessage();
             var parsed = values.Length >= 7 &&
-                         DateTime.TryParseExact(values[0], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &&
-                         double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out high) &&
-                         double.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out low) &&
-                         double.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out open) &&
-                         double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out close) &&
-                         long.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out periodVolume) &&
+                         DateTime.TryParseExact(values[0], DailyWeeklyMonthlyDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &
+                         double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out high) &
+                         double.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out low) &
+                         double.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out open) &
+                         double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out close) &
+                         long.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out periodVolume) &
                          int.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out openInterest);
 
-            if (!parsed)
-                return false;
-
             dailyWeeklyMonthlyMessage = new DailyWeeklyMonthlyMessage(timestamp, high, low, open, close, periodVolume, openInterest);
-            return true;
+            return parsed;
         }
 
         public static DailyWeeklyMonthlyMessage ParseWithRequestId(string message)

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IIntervalMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IIntervalMessage.cs
@@ -9,7 +9,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         double Low { get; }
         int NumberOfTrades { get; }
         double Open { get; }
-        int PeriodVolume { get; }
+        long PeriodVolume { get; }
         long TotalVolume { get; }
     }
 }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IntervalMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/IntervalMessage.cs
@@ -10,7 +10,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
     {
         public const string IntervalDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
 
-        public IntervalMessage(DateTime timestamp, double high, double low, double open, double close, long totalVolume, int periodVolume, int numberOfTrades, string requestId = null)
+        public IntervalMessage(DateTime timestamp, double high, double low, double open, double close, long totalVolume, long periodVolume, int numberOfTrades, string requestId = null)
         {
             Timestamp = timestamp;
             High = high;
@@ -29,7 +29,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         public double Open { get; private set; }
         public double Close { get; private set; }
         public long TotalVolume { get; private set; }
-        public int PeriodVolume { get; private set; }
+        public long PeriodVolume { get; private set; }
         public int NumberOfTrades { get; private set; }
         public string RequestId { get; private set; }
 
@@ -44,38 +44,34 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
                 double.Parse(values[3], CultureInfo.InvariantCulture),
                 double.Parse(values[4], CultureInfo.InvariantCulture),
                 long.Parse(values[5], CultureInfo.InvariantCulture),
-                int.Parse(values[6], CultureInfo.InvariantCulture),
+                long.Parse(values[6], CultureInfo.InvariantCulture),
                 int.Parse(values[7], CultureInfo.InvariantCulture));
         }
 
         public static bool TryParse(string message, out IntervalMessage intervalMessage)
         {
-            intervalMessage = default;
             DateTime timestamp = default;
             double high = default;
             double low = default;
             double open = default;
             double close = default;
             long totalVolume = default;
-            int periodVolume = default;
+            long periodVolume = default;
             int numberOfTrades = default;
 
             var values = message.SplitFeedMessage();
             var parsed = values.Length >= 8 &&
-                         DateTime.TryParseExact(values[0], IntervalDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &&
-                         double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out high) &&
-                         double.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out low) &&
-                         double.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out open) &&
-                         double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out close) &&
-                         long.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &&
-                         int.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out periodVolume) &&
+                         DateTime.TryParseExact(values[0], IntervalDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &
+                         double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out high) &
+                         double.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out low) &
+                         double.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out open) &
+                         double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out close) &
+                         long.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &
+                         long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out periodVolume) &
                          int.TryParse(values[7], NumberStyles.Any, CultureInfo.InvariantCulture, out numberOfTrades);
 
-            if (!parsed)
-                return false;
-
             intervalMessage = new IntervalMessage(timestamp, high, low, open, close, totalVolume, periodVolume, numberOfTrades);
-            return true;
+            return parsed;
         }
 
         public static IntervalMessage ParseWithRequestId(string message)
@@ -90,7 +86,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
                 double.Parse(values[4], CultureInfo.InvariantCulture),
                 double.Parse(values[5], CultureInfo.InvariantCulture),
                 long.Parse(values[6], CultureInfo.InvariantCulture),
-                int.Parse(values[7], CultureInfo.InvariantCulture),
+                long.Parse(values[7], CultureInfo.InvariantCulture),
                 int.Parse(values[8], CultureInfo.InvariantCulture),
                 requestId);
         }

--- a/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Historical/Messages/TickMessage.cs
@@ -11,8 +11,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
         public const string TickDateTimeFormat = "yyyy-MM-dd HH:mm:ss.ffffff";
 
         public TickMessage(DateTime timestamp, double last, int lastSize, int totalVolume, double bid, double ask,
-            long tickId, char basisForLast, int tradeMarketCenter, string tradeConditions, int tradeAggressor,
-            int dayCode, string requestId = null)
+            long tickId, char basisForLast, int tradeMarketCenter, string tradeConditions, int tradeAggressor, int dayCode, string requestId = null)
         {
             Timestamp = timestamp;
             Last = last;
@@ -26,6 +25,36 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             TradeConditions = tradeConditions;
             TradeAggressor = tradeAggressor;
             DayCode = dayCode;
+            RequestId = requestId;
+        }
+
+        /// <summary>
+        /// Backward compatibility constructor for protocol smaller than 6.1
+        /// </summary>
+        /// <param name="timestamp"></param>
+        /// <param name="last"></param>
+        /// <param name="lastSize"></param>
+        /// <param name="totalVolume"></param>
+        /// <param name="bid"></param>
+        /// <param name="ask"></param>
+        /// <param name="tickId"></param>
+        /// <param name="basisForLast"></param>
+        /// <param name="tradeMarketCenter"></param>
+        /// <param name="tradeConditions"></param>
+        /// <param name="requestId"></param>
+        public TickMessage(DateTime timestamp, double last, int lastSize, int totalVolume, double bid, double ask,
+            long tickId, char basisForLast, int tradeMarketCenter, string tradeConditions, string requestId = null)
+        {
+            Timestamp = timestamp;
+            Last = last;
+            LastSize = lastSize;
+            TotalVolume = totalVolume;
+            Bid = bid;
+            Ask = ask;
+            TickId = tickId;
+            BasisForLast = basisForLast;
+            TradeMarketCenter = tradeMarketCenter;
+            TradeConditions = tradeConditions;
             RequestId = requestId;
         }
 
@@ -83,7 +112,6 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
 
         public static bool TryParse(string message, out TickMessage tickMessage)
         {
-            tickMessage = default;
             DateTime timestamp = default;
             double last = default;
             int lastSize = default;
@@ -97,46 +125,40 @@ namespace IQFeed.CSharpApiClient.Lookup.Historical.Messages
             int dayCode = default;
 
             var values = message.SplitFeedMessage();
+            bool parsed;
             if (values.Length <= 11)
             {
                 // old protocol < 6.1 data
-                var parsed = values.Length >= 10 &&
-                             DateTime.TryParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture,
-                                 DateTimeStyles.None, out timestamp) &&
-                             double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out last) &&
-                             int.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out lastSize) &&
-                             int.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &&
-                             double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out bid) &&
-                             double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out ask) &&
-                             long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out tickId) &&
-                             char.TryParse(values[7], out basisForLast) &&
-                             int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture,
-                                 out tradeMarketCenter);
+                parsed = values.Length >= 10 &&
+                             DateTime.TryParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &
+                             double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out last) &
+                             int.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out lastSize) &
+                             int.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &
+                             double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out bid) &
+                             double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out ask) &
+                             long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out tickId) &
+                             char.TryParse(values[7], out basisForLast) &
+                             int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out tradeMarketCenter);
 
-                if (!parsed)
-                    return false;
+                tickMessage = new TickMessage(timestamp, last, lastSize, totalVolume, bid, ask, tickId, basisForLast, tradeMarketCenter, values[9]);
+                return parsed;
             }
-            else
-            {
-                var parsed = values.Length >= 10 &&
-                             DateTime.TryParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &&
-                             double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out last) &&
-                             int.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out lastSize) &&
-                             int.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &&
-                             double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out bid) &&
-                             double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out ask) &&
-                             long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out tickId) &&
-                             char.TryParse(values[7], out basisForLast) &&
-                             int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out tradeMarketCenter) &&
-                             int.TryParse(values[10], NumberStyles.Any, CultureInfo.InvariantCulture, out tradeAggressor) &&
-                             int.TryParse(values[11], NumberStyles.Any, CultureInfo.InvariantCulture, out dayCode);
 
-                if (!parsed)
-                    return false;
-            }
+            parsed = values.Length >= 12 &&
+                         DateTime.TryParseExact(values[0], TickDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timestamp) &
+                         double.TryParse(values[1], NumberStyles.Any, CultureInfo.InvariantCulture, out last) &
+                         int.TryParse(values[2], NumberStyles.Any, CultureInfo.InvariantCulture, out lastSize) &
+                         int.TryParse(values[3], NumberStyles.Any, CultureInfo.InvariantCulture, out totalVolume) &
+                         double.TryParse(values[4], NumberStyles.Any, CultureInfo.InvariantCulture, out bid) &
+                         double.TryParse(values[5], NumberStyles.Any, CultureInfo.InvariantCulture, out ask) &
+                         long.TryParse(values[6], NumberStyles.Any, CultureInfo.InvariantCulture, out tickId) &
+                         char.TryParse(values[7], out basisForLast) &
+                         int.TryParse(values[8], NumberStyles.Any, CultureInfo.InvariantCulture, out tradeMarketCenter) &
+                         int.TryParse(values[10], NumberStyles.Any, CultureInfo.InvariantCulture, out tradeAggressor) &
+                         int.TryParse(values[11], NumberStyles.Any, CultureInfo.InvariantCulture, out dayCode);
 
             tickMessage = new TickMessage(timestamp, last, lastSize, totalVolume, bid, ask, tickId, basisForLast, tradeMarketCenter, values[9], tradeAggressor, dayCode);
-            return true;
+            return parsed;
         }
 
         public static TickMessage ParseWithRequestId(string message)


### PR DESCRIPTION
- increase IntervalMessage.PeriodVolume to long
- add more info in InvalidDataIQFeedException

fixes #122, fixes #124

