### PR TITLE
fix to support protocol 6.2 changes in L2 streaming example

### DIFF
--- a/src/IQFeed.CSharpApiClient.Examples/Examples/StreamingLevel2/StreamingLevel2Example.cs
+++ b/src/IQFeed.CSharpApiClient.Examples/Examples/StreamingLevel2/StreamingLevel2Example.cs
@@ -9,7 +9,7 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.StreamingLevel2
 {
     public class StreamingLevel2Example : IExampleAsync
     {
-        public bool Enable => false; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
+        public bool Enable => true; // *** SET TO TRUE TO RUN THIS EXAMPLE ***
         public string Name => nameof(StreamingLevel2Example);
 
         public async Task RunAsync()
@@ -32,22 +32,53 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.StreamingLevel2
             level2Client.System += Level2ClientOnSystem;
             level2Client.Error += Level2ClientOnError;
 
-            level2Client.Summary += Level2ClientOnSummary;
-            level2Client.Update += Level2ClientOnSummary;
+            //level2Client.Summary += Level2ClientOnSummary; // protocol 6.1 and prior
+            //level2Client.Update += Level2ClientOnSummary; // protocol 6.1 and prior
+
+            // Comment/uncomment the following line for MBP data **********************************
+            //level2Client.PriceLevelSummary += Level2Client_PriceLevelSummary;
+            //level2Client.PriceLevelUpdate += Level2Client_PriceLevelSummary;
+
+            // Comment/uncomment the following line for MBO data **********************************
+            level2Client.OrderSummary += Level2Client_MBOSummary;
+            level2Client.OrderUpdate += Level2Client_MBOSummary;
+
             level2Client.Timestamp += Level2ClientOnTimestamp;
 
             // Step 6 - Make your streaming Level 2 requests
-            level2Client.ReqWatch("@ES#");
+            // ReqWatch is only supported in protocols 6.1 and below.
+            // For protocol 6.2+, use ReqWatchMarketByPrice or ReqWatchMarketByOrder 
+            //level2Client.ReqWatchMarketByPrice("@ES#"); // MBP data *******************************
+            level2Client.ReqWatchMarketByOrder("@ES#"); // MBO data *******************************
 
-            Console.WriteLine("Watching @ES# for the next 30 seconds... Please be patient ;-)\n");
-            await Task.Delay(TimeSpan.FromSeconds(30));
+            Console.WriteLine("Watching @ES# (front month) for the next 20 seconds... Please be patient ;-)\n");
+            await Task.Delay(TimeSpan.FromSeconds(20));
 
             // Step 7 - Unwatch and unregister events
             level2Client.ReqUnwatch("@ES#");
 
-            level2Client.Summary -= Level2ClientOnSummary;
-            level2Client.Update -= Level2ClientOnSummary;
+            //level2Client.Summary -= Level2ClientOnSummary; // protocol 6.1 and prior
+            //level2Client.Update -= Level2ClientOnSummary; // protocol 6.1 and prior
+
+            // Comment/uncomment the following 2 lines for MBP data *******************************
+            //level2Client.PriceLevelSummary -= Level2Client_PriceLevelSummary;
+            //level2Client.PriceLevelUpdate -= Level2Client_PriceLevelSummary;
+
+            // Comment/uncomment the following 2 lines for MBO data *******************************
+            level2Client.OrderSummary -= Level2Client_MBOSummary;
+            level2Client.OrderUpdate -= Level2Client_MBOSummary;
+
             level2Client.Timestamp -= Level2ClientOnTimestamp;
+        }
+
+        private void Level2Client_PriceLevelSummary(PriceLevelUpdateSummaryMessage msg)    // Added for protocol 6.2 MBP
+        {
+            Console.WriteLine(msg);
+        }
+
+        private void Level2Client_MBOSummary(OrderAddUpdateSummaryMessage msg)    // Added for protocol 6.2 MBO
+        {
+            Console.WriteLine(msg);
         }
 
         private void Level2ClientOnTimestamp(TimestampMessage msg)
@@ -55,10 +86,10 @@ namespace IQFeed.CSharpApiClient.Examples.Examples.StreamingLevel2
             Console.WriteLine(msg);
         }
 
-        private void Level2ClientOnSummary(UpdateSummaryMessage msg)
-        {
-            Console.WriteLine(msg);
-        }
+        //private void Level2ClientOnSummary(UpdateSummaryMessage msg) // protocol 6.1 and prior
+        //{
+        //    Console.WriteLine(msg);
+        //}
 
         private void Level2ClientOnError(ErrorMessage msg)
         {


### PR DESCRIPTION
I had issues with projects targeting .NET Framework 4.6.1 and could not find the SDK so I targeted 4.6.2 in my local repo but did not include any of those changes.  A second PR for a new demo project will be coming soon.