### PR TITLE
Fix issue with disposed socket during receive

### DIFF
--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -120,10 +120,17 @@ namespace IQFeed.CSharpApiClient.Socket
                 if (_disposed)
                     return;
 
-                var willRaiseEvent = _clientSocket.ReceiveAsync(e);
-                if (!willRaiseEvent)
+                try
                 {
-                    ProcessReceive(e);
+                    var willRaiseEvent = _clientSocket?.ReceiveAsync(e) ?? false;
+                    if (!willRaiseEvent)
+                    {
+                        ProcessReceive(e);
+                    }
+                }
+                catch(ObjectDisposedException)
+                {
+                    // don't care as the receive is closing anyway
                 }
             }
         }


### PR DESCRIPTION
I had a problem with an uncatchable ObjectDisposedException occurring occasionally during receive, usually when I was closing a connection.

The client socket is obviously being disposed during the receive operation, and thus isn't caught by the disposed check.

The extra two layers of test and catch seems to have fixed it for us, although @mathpaquette might have a more elegant fix.

Nich