### PR TITLE
Added option to set the MaxPriceLevels when requesting level 2 market data by prices

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests.Integration/Streaming/Level2/Level2ClientTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests.Integration/Streaming/Level2/Level2ClientTests.cs
@@ -120,6 +120,23 @@ namespace IQFeed.CSharpApiClient.Tests.Integration.Streaming.Level2
         }
 
         [Test, MaxTime(TimeoutMs)]
+        public void Should_Receive_Summary_When_ReqWatchMarketByPrice_With_MaxPriceLevels()
+        {
+            // Arrange
+            var eventRaised = new ManualResetEvent(false);
+            _level2Client.PriceLevelSummary += message =>
+            {
+                eventRaised.Set();
+            };
+
+            // Act
+            _level2Client.ReqWatchMarketByPrice(Symbol, 10);
+
+            // Assert
+            Assert.IsTrue(eventRaised.WaitOne());
+        }
+
+        [Test, MaxTime(TimeoutMs)]
         [Description("Ignore the test if market closed")]
         public void Should_Receive_Update_When_ReqWatchMarketByPrice()
         {

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Common/Messages/SymbolHasNoDepthAvailableMessageTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Common/Messages/SymbolHasNoDepthAvailableMessageTests.cs
@@ -1,0 +1,24 @@
+﻿using IQFeed.CSharpApiClient.Streaming.Common.Messages;
+using IQFeed.CSharpApiClient.Tests.Common;
+using NUnit.Framework;
+
+namespace IQFeed.CSharpApiClient.Tests.Streaming.Common.Messages
+{
+    public class SymbolHasNoDepthAvailableMessageTests
+    {
+        [Test, TestCaseSource(typeof(CultureNameTestCase), nameof(CultureNameTestCase.CultureNames))]
+        public void Should_Parse_SymbolHasNoDepthAvailableMessage_Culture_Independent(string cultureName)
+        {
+            // Arrange
+            TestHelper.SetThreadCulture(cultureName);
+            var message = "q,MSFT";
+
+            // Act
+            var symbolHasNoDepthAvailableMessageParsed = SymbolHasNoDepthAvailableMessage.Parse(message);
+            var symbolHasNoDepthAvailableMessage = new SymbolHasNoDepthAvailableMessage("MSFT");
+
+            // Assert
+            Assert.AreEqual(symbolHasNoDepthAvailableMessageParsed, symbolHasNoDepthAvailableMessage);
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Level2MessageHandlerTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Level2MessageHandlerTests.cs
@@ -147,6 +147,26 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2
         }
 
         [Test]
+        public void Should_Receive_SymbolHasNoDepthAvailable()
+        {
+            // Arrange
+            var message = TestHelper.GetMessageBytes("q,MSFT\r\n");
+            var expectedMessage = new SymbolHasNoDepthAvailableMessage("MSFT");
+
+            SymbolHasNoDepthAvailableMessage symbolHasNoDepthAvailableMessage = null;
+            _level2MessageHandler.SymbolHasNoDepthAvailable += msg =>
+            {
+              symbolHasNoDepthAvailableMessage = msg;
+            };
+
+            // Act
+            _level2MessageHandler.ProcessMessages(message, message.Length);
+
+            // Assert
+            Assert.AreEqual(symbolHasNoDepthAvailableMessage, expectedMessage);
+        }
+
+        [Test]
         public void Should_Receive_Error()
         {
             // Arrange

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Messages/Level2MessageTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Messages/Level2MessageTests.cs
@@ -88,7 +88,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2.Messages
         }
 
         [Test, TestCaseSource(typeof(CultureNameTestCase), nameof(CultureNameTestCase.CultureNames))]
-        public void Should_Parse_PriceLevelDeleteMessage_Culture_Independent(string cultureName)
+        public void Should_Parse_PriceLevelDeleteMessage_Ask_Culture_Independent(string cultureName)
         {
             // Arrange
             TestHelper.SetThreadCulture(cultureName);
@@ -99,6 +99,23 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2.Messages
             TimeSpan.TryParseExact("20:31:04.876740", PriceLevelDeleteMessage.UpdateMessageTimeFormat, CultureInfo.InvariantCulture, TimeSpanStyles.None, out var time);
             DateTime.TryParseExact("2019-04-23", PriceLevelDeleteMessage.UpdateMessageDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
             var priceLevelDeleteMessage = new PriceLevelDeleteMessage(Level2MessageType.PriceLevelDelete, "@ESM19", Level2Side.Sell, 2938.25, time, date);
+
+            // Assert
+            Assert.AreEqual(priceLevelDeleteMessageParsed, priceLevelDeleteMessage);
+        }
+
+        [Test, TestCaseSource(typeof(CultureNameTestCase), nameof(CultureNameTestCase.CultureNames))]
+        public void Should_Parse_PriceLevelDeleteMessage_Bid_Culture_Independent(string cultureName)
+        {
+            // Arrange
+            TestHelper.SetThreadCulture(cultureName);
+            var priceLevelDeleteMessageString = "9,@ESM19,B,2938.25,20:31:04.876740,2019-04-23,";
+
+            // Act
+            var priceLevelDeleteMessageParsed = PriceLevelDeleteMessage.Parse(priceLevelDeleteMessageString);
+            TimeSpan.TryParseExact("20:31:04.876740", PriceLevelDeleteMessage.UpdateMessageTimeFormat, CultureInfo.InvariantCulture, TimeSpanStyles.None, out var time);
+            DateTime.TryParseExact("2019-04-23", PriceLevelDeleteMessage.UpdateMessageDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
+            var priceLevelDeleteMessage = new PriceLevelDeleteMessage(Level2MessageType.PriceLevelDelete, "@ESM19", Level2Side.Buy, 2938.25, time, date);
 
             // Assert
             Assert.AreEqual(priceLevelDeleteMessageParsed, priceLevelDeleteMessage);

--- a/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupMessageHandler.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/Common/BaseLookupMessageHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using IQFeed.CSharpApiClient.Common;
 using IQFeed.CSharpApiClient.Extensions;
@@ -10,6 +11,7 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
     {
         private static readonly string EndMessagePattern = IQFeedDefault.ProtocolEndOfMessageCharacters + IQFeedDefault.ProtocolDelimiterCharacter;
         private static readonly char[] ValueDelimiter = { IQFeedDefault.ProtocolDelimiterCharacter };
+        private static readonly string FieldsDelimiter = IQFeedDefault.ProtocolDelimiterCharacter.ToString();
 
         public delegate T3 TryParseDelegate<in T1, T2, out T3>(T1 input, out T2 output);
 
@@ -96,11 +98,11 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
             if (possibleErrorValues[0][0] != IQFeedDefault.PrototolErrorCharacter)
                 return string.Empty;
 
-            // error message will be composed of two values (E and error)
-            if (possibleErrorValues.Length != 2)
+            // error message will be composed of two values or three (E and error)
+            if (possibleErrorValues.Length < 2 || possibleErrorValues.Length > 3)
                 return string.Empty;
 
-            return possibleErrorValues[1];
+            return string.Join(FieldsDelimiter, possibleErrorValues.Skip(1));
         }
 
         protected string ParseErrorMessageWithRequestId(string[] messages)
@@ -116,10 +118,10 @@ namespace IQFeed.CSharpApiClient.Lookup.Common
                 return string.Empty;
 
             // error message will be composed of three values (requestId and E and error)
-            if (possibleErrorValues.Length != 3)
+            if (possibleErrorValues.Length < 3 || possibleErrorValues.Length > 4)
                 return string.Empty;
 
-            return possibleErrorValues[2];
+            return string.Join(FieldsDelimiter, possibleErrorValues.Skip(2));
         }
-    }
+  }
 }

--- a/src/IQFeed.CSharpApiClient/Streaming/Common/Messages/SymbolHasNoDepthAvailableMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Common/Messages/SymbolHasNoDepthAvailableMessage.cs
@@ -1,0 +1,39 @@
+﻿using IQFeed.CSharpApiClient.Extensions;
+
+namespace IQFeed.CSharpApiClient.Streaming.Common.Messages
+{
+    public class SymbolHasNoDepthAvailableMessage
+{
+        public SymbolHasNoDepthAvailableMessage(string symbol)
+        {
+            Symbol = symbol;
+        }
+
+        public string Symbol { get; private set; }
+
+        public static SymbolHasNoDepthAvailableMessage Parse(string message)
+        {
+            var values = message.SplitFeedMessage();
+            return new SymbolHasNoDepthAvailableMessage(values[1]);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is SymbolHasNoDepthAvailableMessage message &&
+                   Symbol == message.Symbol;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return -1758840423 + Symbol.GetHashCode();
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Symbol)}: {Symbol}";
+        }
+    }
+}

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/ILevel2Client.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/ILevel2Client.cs
@@ -5,7 +5,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
     public interface ILevel2Client : IClient, ILevel2Event, ILevel2Snapshot
     {
         void ReqWatch(string symbol);
-        void ReqWatchMarketByPrice(string symbol);
+        void ReqWatchMarketByPrice(string symbol, int? maxPriceLevels = null);
         void ReqWatchMarketByOrder(string symbol);
         void ReqMarketMakerNameById(string mmid);
         void ReqUnwatch(string symbol);

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/ILevel2Event.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/ILevel2Event.cs
@@ -9,6 +9,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
         event Action<UpdateSummaryMessage> Summary;
         event Action<UpdateSummaryMessage> Update;
         event Action<SymbolNotFoundMessage> SymbolNotFound;
+        event Action<SymbolHasNoDepthAvailableMessage> SymbolHasNoDepthAvailable;
         event Action<MarketMakerNameMessage> Query;
         event Action<ErrorMessage> Error;
         event Action<TimestampMessage> Timestamp;

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2Client.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2Client.cs
@@ -19,6 +19,11 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
             add => _level2MessageHandler.SymbolNotFound += value;
             remove => _level2MessageHandler.SymbolNotFound -= value;
         }
+        public event Action<SymbolHasNoDepthAvailableMessage> SymbolHasNoDepthAvailable
+        {
+            add => _level2MessageHandler.SymbolHasNoDepthAvailable += value;
+            remove => _level2MessageHandler.SymbolHasNoDepthAvailable -= value;
+        }
         public event Action<ErrorMessage> Error
         {
             add => _level2MessageHandler.Error += value;

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2Client.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2Client.cs
@@ -141,14 +141,14 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
             _socketClient.Send(request);
         }
 
-        public void ReqWatchMarketByPrice(string symbol)
+        public void ReqWatchMarketByPrice(string symbol, int? maxPriceLevels = null)
         {
             if (GetProtocolVersionAsNumber() <= 6.1M)
             {
                 throw new Exception($"ReqWatchMarketByPrice is only supported in protocols 6.2 and above.");
             }
 
-            var request = _level2RequestFormatter.ReqWatchMarketByPrice(symbol);
+            var request = _level2RequestFormatter.ReqWatchMarketByPrice(symbol, maxPriceLevels);
             _socketClient.Send(request);
         }
 

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2MessageHandler.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2MessageHandler.cs
@@ -11,6 +11,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
         public event Action<UpdateSummaryMessage> Summary;
         public event Action<UpdateSummaryMessage> Update;
         public event Action<SymbolNotFoundMessage> SymbolNotFound;
+        public event Action<SymbolHasNoDepthAvailableMessage> SymbolHasNoDepthAvailable;
         public event Action<MarketMakerNameMessage> Query;
         public event Action<ErrorMessage> Error;
         public event Action<TimestampMessage> Timestamp;
@@ -76,6 +77,10 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
                         break;
                     case 'n': // Symbol not found message
                         ProcessSymbolNotFoundMessage(message);
+                        break;
+                    case 'q': // No depth available message. (protocol 6.2 and above)
+                              // This message is received when a symbol is valid but there is currently no depth available.  
+                        ProcessSymbolHasNoDepthAvailableMessage(message);
                         break;
                     case 'E': // An error message
                         ProcessErrorMessage(message);
@@ -170,6 +175,12 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
         {
             var symbolNotFoundMessage = SymbolNotFoundMessage.Parse(msg);
             SymbolNotFound?.Invoke(symbolNotFoundMessage);
+        }
+
+        private void ProcessSymbolHasNoDepthAvailableMessage(string msg)
+        {
+            var symbolHasNoDepthAvailableMessage = SymbolHasNoDepthAvailableMessage.Parse(msg);
+            SymbolHasNoDepthAvailable?.Invoke(symbolHasNoDepthAvailableMessage);
         }
 
         private void ProcessErrorMessage(string msg)

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2RequestFormatter.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Level2RequestFormatter.cs
@@ -9,9 +9,11 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2
             return $"w{symbol.ToUpper()}{IQFeedDefault.ProtocolTerminatingCharacters}";
         }
 
-        public string ReqWatchMarketByPrice(string symbol)
+        public string ReqWatchMarketByPrice(string symbol, int? maxPriceLevels = null)
         {
-            return $"WPL,{symbol.ToUpper()}{IQFeedDefault.ProtocolTerminatingCharacters}";
+            return maxPriceLevels.HasValue 
+                ? $"WPL,{symbol.ToUpper()},{maxPriceLevels.Value}{IQFeedDefault.ProtocolTerminatingCharacters}"
+                : $"WPL,{symbol.ToUpper()}{IQFeedDefault.ProtocolTerminatingCharacters}";
         }
 
         public string ReqWatchMarketByOrder(string symbol)

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Messages/PriceLevelDeleteMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Messages/PriceLevelDeleteMessage.cs
@@ -20,7 +20,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2.Messages
         {
             MessageType = messageType;
             Symbol = symbol;
-            Side = Side;
+            Side = side;
             Price = price;
             Time = time;
             Date = date;


### PR DESCRIPTION
Hi,

This PR includes PR https://github.com/mathpaquette/IQFeed.CSharpApiClient/pull/162

I added an option to set the MaxPriceLevels retrieved when requesting level 2 market data by prices.
It's a built in option in the WPL request, just need to fill it.
This option is useful if you want to display the book and don't want to deal with too many levels of market data.

The method `ILevel2Client.ReqWatchMarketByPrice` prototype changed from:
  `void ReqWatchMarketByPrice(string symbol);` 
to 
  `void ReqWatchMarketByPrice(string symbol, int? maxPriceLevels = null);`

When maxPriceLevels = null it falls back to the original implemetation that doesn't provide this argument.

Ami
