### PR TITLE
Eliminate the initial burst during lookups

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
@@ -113,7 +113,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup
             var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
 
             // Assert
-            var expectedMaxCount = 50;            
+            var expectedMaxCount = 50;
             Assert.AreEqual(lookupRateLimiter.MaxCount, expectedMaxCount);
         }
 

--- a/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Lookup/LookupRateLimiterTests.cs
@@ -113,7 +113,7 @@ namespace IQFeed.CSharpApiClient.Tests.Lookup
             var lookupRateLimiter = new LookupRateLimiter(requestsPerSecond);
 
             // Assert
-            var expectedMaxCount = 25;
+            var expectedMaxCount = 50;            
             Assert.AreEqual(lookupRateLimiter.MaxCount, expectedMaxCount);
         }
 

--- a/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/LookupRateLimiter.cs
@@ -46,14 +46,17 @@ namespace IQFeed.CSharpApiClient.Lookup
         private async Task ReleaseSemaphoreAsync(TimeSpan interval, int maxCount)
         {
             // start only after the first request goes through
-            while (!_started)
+            while (!_started && _running)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
             }
 
-            // calm down the initial burst by delaying leaky bucket operation for one second
-            // this allows gracefully consume the initial per second allowance without going over the limit
-            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            if (_running) // if we dispose before the first request no need to wait
+            {
+                // calm down the initial burst by delaying leaky bucket operation for one second
+                // this allows gracefully consume the initial per second allowance without going over the limit
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            }
             
             var intervalTicks = (int)interval.Ticks;
             var remainderTicks = 0;


### PR DESCRIPTION
Eliminated the initial bursts by tuning up leaky bucket operation that now starts 1 second after the very first request.

Fixes https://github.com/mathpaquette/IQFeed.CSharpApiClient/issues/168
