### PR TITLE
170-race-condition-in-socketclient-processreceive

### DIFF
--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Level2MessageHandlerTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Level2MessageHandlerTests.cs
@@ -315,7 +315,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2
             var message = TestHelper.GetMessageBytes("7,@ESM19,B,2938.25,65,11,2,20:31:04.876740,2019-04-23,\r\n");
             TimeSpan.TryParseExact("20:31:04.876740", PriceLevelUpdateSummaryMessage.UpdateMessageTimeFormat, CultureInfo.InvariantCulture, TimeSpanStyles.None, out var time);
             DateTime.TryParseExact("2019-04-23", PriceLevelUpdateSummaryMessage.UpdateMessageDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
-            var expectedMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelSummary, "@ESM19", Level2Side.Buy, 2938.25, 65, 10, 2, time, date);
+            var expectedMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelSummary, "@ESM19", Level2Side.Buy, 2938.25, 65, 11, 2, time, date);
 
             PriceLevelUpdateSummaryMessage receivedMessage = null;
             _level2MessageHandler.PriceLevelSummary += msg =>
@@ -337,7 +337,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2
             var message = TestHelper.GetMessageBytes("8,@ESM19,B,2938.25,65,11,2,20:31:04.876740,2019-04-23,\r\n");
             TimeSpan.TryParseExact("20:31:04.876740", PriceLevelUpdateSummaryMessage.UpdateMessageTimeFormat, CultureInfo.InvariantCulture, TimeSpanStyles.None, out var time);
             DateTime.TryParseExact("2019-04-23", PriceLevelUpdateSummaryMessage.UpdateMessageDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
-            var expectedMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelUpdate, "@ESM19", Level2Side.Buy, 2938.25, 65, 10, 2, time, date);
+            var expectedMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelUpdate, "@ESM19", Level2Side.Buy, 2938.25, 65, 11, 2, time, date);
 
             PriceLevelUpdateSummaryMessage receivedMessage = null;
             _level2MessageHandler.PriceLevelUpdate += msg =>

--- a/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Messages/Level2MessageTests.cs
+++ b/src/IQFeed.CSharpApiClient.Tests/Streaming/Level2/Messages/Level2MessageTests.cs
@@ -80,7 +80,7 @@ namespace IQFeed.CSharpApiClient.Tests.Streaming.Level2.Messages
             TimeSpan.TryParseExact("20:31:04.876740", PriceLevelUpdateSummaryMessage.UpdateMessageTimeFormat, CultureInfo.InvariantCulture, TimeSpanStyles.None, out var time);
             DateTime.TryParseExact("2019-04-23", PriceLevelUpdateSummaryMessage.UpdateMessageDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date);
             var priceLevelUpdateMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelUpdate, "@ESM19", Level2Side.Sell, 2938.25, 65, 10, 2, time, date);
-            var priceLevelSummaryMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelSummary, "@ESM19", Level2Side.Buy, 2938.25, 65, 10, 2, time, date);
+            var priceLevelSummaryMessage = new PriceLevelUpdateSummaryMessage(Level2MessageType.PriceLevelSummary, "@ESM19", Level2Side.Buy, 2938.25, 65, 11, 2, time, date);
 
             // Assert
             Assert.AreEqual(priceLevelUpdateMessageParsed, priceLevelUpdateMessage);

--- a/src/IQFeed.CSharpApiClient/Lookup/MarketSummary/Messages/MarketSummaryMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Lookup/MarketSummary/Messages/MarketSummaryMessage.cs
@@ -284,7 +284,6 @@ namespace IQFeed.CSharpApiClient.Lookup.MarketSummary.Messages
                 return null;
             }
 
-            var index = 0;
             var values = message.SplitFeedMessage();
             return new MarketSummaryMessage(values, marketSummaryHandler);
         }

--- a/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
+++ b/src/IQFeed.CSharpApiClient/Socket/SocketClient.cs
@@ -104,24 +104,24 @@ namespace IQFeed.CSharpApiClient.Socket
             // check if the remote host closed the connection
             if (e.BytesTransferred > 0 && e.SocketError == SocketError.Success)
             {
-                _socketMessageHandler.Write(e.Buffer, e.Offset, e.BytesTransferred);
-                var count = _socketMessageHandler.TryRead(out var readBytes);
-
-                if (count > 0)
-                {
-                    _socketMessageEventArgs.Message = readBytes;
-                    _socketMessageEventArgs.Count = count;
-
-                    // inform that the socket just received complete message
-                    MessageReceived.RaiseEvent(this, _socketMessageEventArgs);
-                }
-
-                // don't attempt another receive if socket is already disposed
-                if (_disposed)
-                    return;
-
                 try
                 {
+                    _socketMessageHandler.Write(e.Buffer, e.Offset, e.BytesTransferred);
+                    var count = _socketMessageHandler.TryRead(out var readBytes);
+
+                    if (count > 0)
+                    {
+                        _socketMessageEventArgs.Message = readBytes;
+                        _socketMessageEventArgs.Count = count;
+
+                        // inform that the socket just received complete message
+                        MessageReceived.RaiseEvent(this, _socketMessageEventArgs);
+                    }
+                
+                    // don't attempt another receive if socket is already disposed
+                    if (_disposed)
+                        return;
+
                     var willRaiseEvent = _clientSocket?.ReceiveAsync(e) ?? false;
                     if (!willRaiseEvent)
                     {
@@ -130,7 +130,8 @@ namespace IQFeed.CSharpApiClient.Socket
                 }
                 catch(ObjectDisposedException)
                 {
-                    // don't care as the receive is closing anyway
+                    if(!_disposed) throw; // something wrong
+                    // otherwise don't care as the receive is closing anyway
                 }
             }
         }

--- a/src/IQFeed.CSharpApiClient/Streaming/Level2/Messages/PriceLevelUpdateSummaryMessage.cs
+++ b/src/IQFeed.CSharpApiClient/Streaming/Level2/Messages/PriceLevelUpdateSummaryMessage.cs
@@ -29,7 +29,7 @@ namespace IQFeed.CSharpApiClient.Streaming.Level2.Messages
             Side = side;
             Price = price;
             Size = size;
-            orderCount = orderCount;
+            OrderCount = orderCount;
             Precision = precision;
             Time = time;
             Date = date;


### PR DESCRIPTION
1. Fixed the race condition that would sometimes crash the host application when disposing the IQFeed client.
2. Fixed the typo in Level2 PriceLevelUpdateSummaryMessage constructor and related tests
3. Removed leftover unused variable